### PR TITLE
More efficient file loading

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -49,30 +49,25 @@ class Clarkson_Core {
 		$theme_dir = get_template_directory();
 
 		foreach($dirs as $dir){
-			$this->load_php_files_from_path( $theme_dir . "/{$dir}" );
+			if(is_string($theme_dir . "/{$dir}") && file_exists($theme_dir . "/{$dir}") ){
+				$this->load_php_files_from_path( $theme_dir . "/{$dir}" );
+			}
 		}
 
 	}
 
-	private function load_php_files_from_path($path = false){
-
-		if( !$path || !is_string($path) || !file_exists($path) )
-			return;
-
-		$files = glob("{$path}/*.php");
-		$dirs = array_filter(glob("{$path}/*", GLOB_ONLYDIR), 'is_dir');
-
-		foreach($dirs as $dir){
-			$this->load_php_files_from_path($dir);
+	private function load_php_files_from_path($path){
+		$handle = opendir($path);
+		while (false !== ($entry = readdir($handle))) {
+			$fullPath = $path . "/$entry";
+			if(strrchr($entry, '.') == '.php'){
+				require_once($fullPath);
+			}elseif($entry != '.' && $entry != '..'){
+				if(filetype($fullPath) == 'dir'){
+					$this->load_php_files_from_path($fullPath);
+				}
+			}
 		}
-
-		if( empty($files) )
-			return;
-
-		foreach ( $files as $filepath){
-			require_once $filepath;
-		}
-
 	}
 
 	// Singleton
@@ -114,3 +109,4 @@ class Clarkson_Core {
 }
 
 add_action('plugins_loaded', array('Clarkson_Core', 'get_instance'));
+


### PR DESCRIPTION
Improves loading of directories

```
'functions',
'post-types',
'taxonomies' 
```

Benchmark command: `ab -t 60 http://local.wordpress.dev/`

**Before optimisations:**
Requests per second:    1.31 [#/sec](mean)
Time per request:       764.625 [ms](mean)

**After optimisations:** 
Requests per second:    2.51 [#/sec](mean)
Time per request:       398.248 [ms](mean)

This change does break backward-compatibility with code that relies on loading files in certain order, as  file inclusion becomes linear instead of depth first.

See the attached files for benchmarks and changes.
[optimized.ab.txt](https://github.com/level-level/Clarkson-Core/files/457732/optimized.ab.txt)
[optimized.files.txt](https://github.com/level-level/Clarkson-Core/files/457730/optimized.files.txt)
[optimized webgrind](https://cloud.githubusercontent.com/assets/661876/18290405/933fbb32-7483-11e6-830c-00fef4d8b7df.png)
[original.ab.txt](https://github.com/level-level/Clarkson-Core/files/457729/original.ab.txt)
[original.files.txt](https://github.com/level-level/Clarkson-Core/files/457731/original.files.txt)
[original webgrind](https://cloud.githubusercontent.com/assets/661876/18290404/933f3036-7483-11e6-8763-7df6e56405fa.png)
