### PR TITLE
Deprecated yall_twig_functions for clarkson_twig_function

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -24,6 +24,11 @@ class Clarkson_Core {
 		// Load lib
 		$this->load_php_files_from_path( __DIR__ . '/lib' );
 
+		// Deprecated functions and filters
+		if( class_exists('Clarkson_Core_Deprecated') ){
+			Clarkson_Core_Deprecated::get_instance();
+		}
+
 		// Load post objects
 		if( class_exists('Clarkson_Core_Objects') ){
 			Clarkson_Core_Objects::get_instance();

--- a/lib/clarkson-core-deprecated.php
+++ b/lib/clarkson-core-deprecated.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Handle renamed filters.
+ *
+ * Based on Mikey Jolley's example in WooCommerce
+ * https://mikejolley.com/2013/12/15/deprecating-plugin-functions-hooks-woocommmerce/
+ * and
+ * https://github.com/woocommerce/woocommerce/blob/master/includes/wc-deprecated-functions.php
+ *
+ */
+
+class Clarkson_Core_Deprecated {
+    var $map_deprecated_filters;
+
+    public function __construct(){
+        $this->set_map_deprecated_filters();
+        foreach ( $this->map_deprecated_filters as $new => $old ) {
+            add_filter( $new, array( $this, 'deprecated_filter_mapping' ) );
+        }
+    }
+
+    public function get_map_deprecated_filters(){
+        return array(
+            'clarkson_twig_functions' => 'yalla_twig_functions'
+        );
+    }
+
+    public function set_map_deprecated_filters(){
+        $this->map_deprecated_filters = $this->get_map_deprecated_filters();
+    }
+
+    public function deprecated_filter_mapping( $data, $arg_1 = '', $arg_2 = '', $arg_3 = '' ) {
+        $map_deprecated_filters = $this->get_map_deprecated_filters();
+
+        $filter = current_filter();
+
+        if ( isset( $map_deprecated_filters[ $filter ] ) ) {
+            if ( has_filter( $map_deprecated_filters[ $filter ] ) ) {
+                $data = apply_filters( $map_deprecated_filters[ $filter ], $data, $arg_1, $arg_2, $arg_3 );
+                if ( ! defined( 'DOING_AJAX' ) ) {
+                    _deprecated_function( 'The ' . $map_deprecated_filters[ $filter ] . ' filter', '', $filter );
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    // Singleton
+    protected $instance = null;
+
+    public static function get_instance()
+    {
+        static $instance = null;
+
+        if (null === $instance) {
+            $instance = new Clarkson_Core_Deprecated();
+        }
+
+        return $instance;
+    }
+}
+
+

--- a/lib/clarkson-core-twig-extension.php
+++ b/lib/clarkson-core-twig-extension.php
@@ -947,7 +947,8 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension
     {
         $twigFunctions = array();
 
-        $allowed_functions = apply_filters( 'yalla_twig_functions', $this->functions);
+        $allowed_functions = apply_filters( 'clarkson_twig_functions', $this->functions);
+		//$allowed_functions = apply_filters( 'clarkson_twig_functions', $allowed_functions);
 
         foreach ($allowed_functions  as $function) {
             $twigFunctions[] = new Twig_SimpleFunction($function,$function);


### PR DESCRIPTION
Fixes #41 

# Deprecate filter
Added a custom way of deprecating a filter because WordPress Core doesn't have a method of doing that. 
See https://mikejolley.com/2013/12/15/deprecating-plugin-functions-hooks-woocommmerce/

# How to reproduce
Add this code in a file to your Clarkson Theme `functions` folder.

```
<?php
function test_function(){
    echo 'echos test_function';
}

function cd_add_filters( $functions ){
    $theme_functions   = array(
        'test_function'
    );
    $functions = array_merge( $functions, $theme_functions );
    return $functions;
}
add_filter( 'yalla_twig_functions', 'cd_add_filters' );
```

2. Call `test_fuction()` from a `.twig` file like `{{ test_function() }}`

# Result when using a deprecated filter.
![clarkson_filters](https://cloud.githubusercontent.com/assets/145887/19270550/de8c1a56-8fc0-11e6-8874-4f9d3268fac9.png)
