### PR TITLE
Return correct value of the_excerpt

### DIFF
--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -263,15 +263,11 @@ class Clarkson_Object {
 
 		if ( ! isset( $this->_excerpt ) ) {
 			setup_postdata( $this->_post );
-
-			ob_start();
-			the_excerpt();
-
-			$this->_excerpt = ob_get_clean();
+			$this->_excerpt = get_the_excerpt( $this->_post );
 			wp_reset_postdata();
 		}
 
-		return $this->_excerpt;
+		return apply_filters( 'the_excerpt', $this->_excerpt );
 
 	}
 


### PR DESCRIPTION
When searching the previous setup returned the_excerpt of the first post.
Because within the_excerpt(), $post was null and it returned the first post. Because it's not proper in "The_Loop"

We now pass $this->_post through `get_the_excerpt` and apply the_except filter if it gets filtered just in case.

When removing `setup_postdata()` it all stopped working... don't now yet why.