### PR TITLE
Add support for custom template directory and so child-themes

### DIFF
--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -121,10 +121,10 @@ class Clarkson_Core_Templates {
 	 * This takes notices of the child / parent hierarchy, so that's why the child theme gets searched first and then the parent theme, just like the regular WordPress templating hierarchy.
 	 */
 	public function get_templates_dirs(){
-		$template_dirs = [
+		$template_dirs = array(
 			$this->get_stylesheet_dir(),
 			$this->get_template_dir(),
-		];
+		);
 
 		// if no child-theme is used, then these two above are the same
 		$template_dirs = array_unique( $template_dirs );


### PR DESCRIPTION
> Pass an array of directories to Twig to load Twig templates from plugin and so also make it possible to support Child themes as an extra ;)

`Twig_Loader_Filesystem` now gets passed an array of directories.

This also introduces a new filter `clarkson_twig_template_dirs` which I
needed at first. If you want to render a Twig file from outside your
theme directory then you need to register that directory to let Twig
search that path.

This also introduces the possibility to first check the child-theme
directory and then the parent theme, because Twig will first search for
the `$template_file` in the first directory and then the second one.