### PR TITLE
Twig version set to 1.2 and get_localized_date renamed to get_date_i18n

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require" : {
-	    "twig/twig":"~1.2",
-        "twig/extensions":"~1.3",
+	"twig/twig":"^1.2",
+        "twig/extensions":"^1.3",
         "symfony/translation": "2.7.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require" : {
-	    "twig/twig":"~1.2|~2.0",
+	    "twig/twig":"~1.2",
         "twig/extensions":"~1.3",
         "symfony/translation": "2.7.7"
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require" : {
-	"twig/twig":"^1.2",
+        "twig/twig":"^1.2",
         "twig/extensions":"^1.3",
         "symfony/translation": "2.7.7"
     }

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -171,16 +171,16 @@ class Clarkson_Object {
 	}
 
 	/**
-     * Get the date localized from the wordpress .mo file.
-     *
-     * @param string $format
-     * @param bool $gmt
-     * @return string
-     */
-    public function get_date_i18n( $format = 'U', $gmt = false ) {
+	 * Get the date in localized format
+	 *
+	 * @param string $format
+	 * @param bool $gmt
+	 * @return string
+	 */
+	public function get_date_i18n( $format = 'U', $gmt = false ) {
 
-        return date_i18n( $format, strtotime( $this->_post->post_date_gmt, $gmt ) );
-    }
+		return date_i18n( $format, strtotime( $this->_post->post_date_gmt, $gmt ) );
+	}
 
 	/**
 	 * Set the post date of the post

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -171,6 +171,18 @@ class Clarkson_Object {
 	}
 
 	/**
+     * Get the date localized from the wordpress .mo file.
+     *
+     * @param string $format
+     * @param bool $gmt
+     * @return string
+     */
+    public function get_date_i18n( $format = 'U', $gmt = false ) {
+
+        return date_i18n( $format, strtotime( $this->_post->post_date_gmt, $gmt ) );
+    }
+
+	/**
 	 * Set the post date of the post
 	 *
 	 * @param int $time PHP timestamp


### PR DESCRIPTION
Twig version set to 1.2 because of PHP version support (2.0 required PHP 7.0) and renamed the get_localized_date function to get_date_i18n.