### PR TITLE
Improvement/templating - Keep this PR open please

### DIFF
--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -169,8 +169,8 @@ class Clarkson_Core_Templates {
             }
         }
 
-		if ( isset( $templates['index'] ) ) {
-			return $templates['index'];
+		if ( isset( $twig_templates['index'] ) ) {
+			return $twig_templates['index'];
 		}
 
 		return $template;


### PR DESCRIPTION
Makes choosing which template file to load in a  more transparent way and in line with the WordPress way of choosing which template it needs to load. 

1. This filter is only available since WP 4.8, so we are waiting with merging this. 
2. choosing singular.twig over index.twig when a page has a custom template but this file is missing on disk is also fixed since WP 4.8 and the introduction of CPT templates. 

Props @christiaanstijnen and @Willemijnr

Keep this one open please untill further notice.