### PR TITLE
Check if Clarkson _Core_Autoloader exists

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -60,6 +60,10 @@ class Clarkson_Core {
 
 		add_action( 'init', array( $this, 'init' ) );
 
+		if ( ! class_exists( 'Clarkson_Core_Autoloader' ) ) {
+			return;
+		}
+
 		$this->autoloader = new Clarkson_Core_Autoloader();
 
 		if ( apply_filters( 'clarkson_core_autoload_theme_pre_020', false ) ) {


### PR DESCRIPTION
Sometimes it happends that when switching to theme that doesn't loads
Clarkson_Core via their composer.json but Clarkson Core is installed as
a mu-plugins without it's own `vendor` folder, then this would trigger
a fatal error. This makes switching themes to easily debug less error
prone. Fixes #111