### PR TITLE
add new WordPress functions to Twig extension

### DIFF
--- a/lib/clarkson-core-twig-extension.php
+++ b/lib/clarkson-core-twig-extension.php
@@ -667,12 +667,19 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 		'__',
 		'_x',
 		'_n',
+		'_ngettext', // deprecated function
+		'_n_noop',
 		'_nx',
+		'_nx_noop',
+		'translate_nooped_plural',
 		'_e',
 		'_ex',
-		'_ngettext',
-		'esc_attr__',
 		'esc_attr_e',
+		'esc_attr_x',
+		'esc_attr__',
+		'esc_html_e',
+		'esc_html_x',
+		'esc_html__',
 		'get_locale',
 		'load_default_textdomain',
 		'load_plugin_textdomain',
@@ -719,6 +726,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 		'get_post_statuses',
 		'get_query_var',
 		'home_url',
+		'get_home_url',
 		'includes_url',
 		'is_blog_installed',
 		'is_main_site',
@@ -924,6 +932,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 		'is_year',
 		'pings_open',
 		'gravity_form', // shouldn't be here...
+		'single_post_title'
 	);
 
 	public function __construct( array $functions = array()) {

--- a/lib/clarkson-core-twig-extension.php
+++ b/lib/clarkson-core-twig-extension.php
@@ -932,7 +932,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 		'is_year',
 		'pings_open',
 		'gravity_form', // shouldn't be here...
-		'single_post_title'
+		'single_post_title',
 	);
 
 	public function __construct( array $functions = array()) {


### PR DESCRIPTION
```
get_home_url
single_post_title
esc_html__
esc_html_x
esc_html_e
esc_attr_x
translate_nooped_plural
_nx_noop
_n_noop
_ngettext
```

Fixes #87