### PR TITLE
Prevent notice of getting WordPress objects by ID

### DIFF
--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -57,8 +57,8 @@ class Clarkson_Core_Objects {
 	 * Get post that's converted to their respectievelijke WordPress object class
 	 */
 	public function get_object( $post ) {
-		if( ! $post instanceof WP_Post && is_int( (int)$post ) ){
-			trigger_error( "Deprecated calling of get_object with an ID. Use a `WP_Post` instead.", E_USER_DEPRECATED );
+		if ( ! $post instanceof WP_Post && is_int( (int) $post ) ) {
+			trigger_error( 'Deprecated calling of get_object with an ID. Use a `WP_Post` instead.', E_USER_DEPRECATED );
 			$post = get_post( $post );
 		}
 		$cc = Clarkson_Core::get_instance();

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -40,28 +40,38 @@ class Clarkson_Core_Objects {
 		return new Clarkson_User( $users_id );
 	}
 
-	public function get_objects( $posts_ids ) {
+	/**
+	 * Get a array of post converted to their respectievelijke WordPress object class
+	 */
+	public function get_objects( $posts ) {
 		$objects = array();
 
-		foreach ( $posts_ids as $posts_id ) {
-			$objects[] = $this->get_object( $posts_id );
+		foreach ( $posts as $post ) {
+			$objects[] = $this->get_object( $post );
 		}
 
 		return $objects;
 	}
 
-	public function get_object( $post_id ) {
+	/**
+	 * Get post that's converted to their respectievelijke WordPress object class
+	 */
+	public function get_object( $post ) {
+		if( ! $post instanceof WP_Post && is_int( (int)$post ) ){
+			trigger_error( "Deprecated calling of get_object with an ID. Use a `WP_Post` instead.", E_USER_DEPRECATED );
+			$post = get_post( $post );
+		}
 		$cc = Clarkson_Core::get_instance();
 
-		$type = get_post_type( $post_id );
+		$type = get_post_type( $post );
 		$type = $cc->autoloader->sanitize_object_name( $type );
 		$type = apply_filters( 'clarkson_object_type', $type );
 
 		if ( in_array( $type, $cc->autoloader->post_types ) && class_exists( $type ) ) {
-			return new $type($post_id);
+			return new $type( $post );
 		}
 
-		return new Clarkson_Object( $post_id );
+		return new Clarkson_Object( $post );
 	}
 
 	private function register_objects() {


### PR DESCRIPTION
```
    echo 'new Clarkson( 32 ) has a notice as it should be';
    $post1 = new Clarkson_Object( 32 );
    echo '<hr/>';

    echo 'Clarkson::get( 32 ) has no notice';
    $post2 = Clarkson_Object::get( 32 );
    echo '<hr/>';

    $cco = \Clarkson_Core_Objects::get_instance();
    echo 'cco->get_objects( [ 32,10 ] ) with IDs has 2 notices';
    $cco->get_objects( [ 32, 10] );
    echo '<hr/>';

    echo 'cco->get_object with ID has a notice';
    $cco->get_object( 32 );
    echo '<hr/>';

    echo 'cco->get_object with WP_post = no notice';
    $wp_post_32 = get_post( 32 );
    $cco->get_object( $wp_post_32 );
    echo '<hr/>';

    echo 'cco->get_objects with WP_post = no notice';
    $wp_posts[] = get_post( 32 );
    $wp_posts[] = get_post( 10 );
    $cco->get_objects( $wp_posts );
    echo '<hr/>';
```

What I did notice is that `Clarkson::get()` uses a `post_id` as argument. Just like every other WordPress object. I know this is outside the scope of this issue, so I won't spend time on that right now. Or even fix it at all ;)