### PR TITLE
Fix template loading

### DIFF
--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -420,7 +420,7 @@ class Clarkson_Core_Templates {
 		foreach ( $templates as $template ) {
 			$base      = basename( $template );
 			$base      = str_replace( '.twig', '', $base );
-			$type      = preg_replace( '|[^a-z0-9-]+|', '', $base );
+			$type      = preg_replace( '|[^a-z0-9]+|', '', $base );
 			$base_type = preg_replace( '(-.*)', '', $type );
 			if ( ! in_array( $base_type, $filters, true ) ) {
 				add_filter( "{$base_type}_template", array( $this, 'add_template' ) );

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -225,7 +225,7 @@ class Clarkson_Core_Templates {
 
 	/**
 	 * Add template.
-	 * 
+	 *
 	 * Returns the Twig file location which WordPress / Clarkson is going to use.
 	 *
 	 * @param string $template Default template.
@@ -242,11 +242,11 @@ class Clarkson_Core_Templates {
 
 		$twig_templates = $this->templates;
 
-		/** 
+		/**
 		 * Loop over the $templates parameter which is an array with all the options that WordPress should load.
 		 * Like archive-projects.php, archive.php. If you have attached a Twig template to a Post Type then it's possible that there is a template-xyz.twig in there.
 		 */
-		foreach( $templates as $template_name ) {
+		foreach ( $templates as $template_name ) {
 			$template_name = str_replace( '.php', '', $template_name );
 
 			// Check if this file really is located in the 'templates' directory.
@@ -266,7 +266,7 @@ class Clarkson_Core_Templates {
 		 *
 		 * Of course only if there is a singular template.
 		 */
-		if ( $type === 'page' && ! isset( $twig_templates[ 'page' ] ) && isset( $twig_templates['singular'] ) ) {
+		if ( 'page' === $type && ! isset( $twig_templates['page'] ) && isset( $twig_templates['singular'] ) ) {
 			$type = 'singular';
 		}
 


### PR DESCRIPTION
# Issue at hand

front-page.twig wasn't used when a page was set to "front-page" via the WordPress dashboard. This means the Theme Template Hierarchy wasn't followed. We also noticed this with the bug that Niels encountered when a Archive was empty and Clarkson previously fell back to 'index'. 

# Fixes 
1.  Don't replace the minus from the basename of the template. Because this way 'front-page.twig' can be used so the correct template hierarchy can be followed.

2. Fix finding the correct twig template file.
Don't incorpate own custom logic because the third $templates parameter contains correct template name to search for according to the Theme Hierarchy.
This method, using the $templates array, also considers the egde-case / bug that @NielsdeBlaauw encoutered: Load the correct archive.twig template when you visit the archive page but there are not Posts in that archive. This because WordPress already take this in account and we now really follow the WordPress flow by using $templates array.

Based on #99 but with some extra documentation, checks and fallbacks. Also tested with variety of possible templates. 

# Backwards compatibilty
Is this code backwards compatible. I do think so, because the issue of not being able to use front-page.twig was often fixed by using a custom page template and applying that to the page. But please enlighten me if that's not the case.