### PR TITLE
extend gutenberg block type with alignment, preview and post_id

### DIFF
--- a/lib/clarkson-core-gutenberg-block-type.php
+++ b/lib/clarkson-core-gutenberg-block-type.php
@@ -72,20 +72,27 @@ class Clarkson_Core_Gutenberg_Block_Type extends \WP_Block_Type {
 	/**
 	 * Tries to find a twig file to use for rendering. If the twig file doesn't
 	 * exists it falls back to the original render callback.
-	 * @param array  $attributes Block attributes.
-	 * @param string $content    Block content.
+	 * @param array  $attributes  Block attributes.
+	 * @param string $content     Block content.
+	 * @param bool   $is_preview  Block preview status.
+	 * @param int    $post_id     Current post id.
 	 * @return string Rendered block type output.
 	 */
-	public function clarkson_render_callback( $attributes, $content ) {
+	public function clarkson_render_callback( $attributes, $content, $is_preview = false, $post_id = 0 ) {
 		if ( file_exists( $this->get_twig_template_path() ) ) {
 			$cc_template              = Clarkson_Core_Templates::get_instance();
 			$this->content_attributes = $attributes;
+			$this->post_id            = $post_id;
+
 			return (string) $cc_template->render_twig(
 				$this->get_twig_template_path(),
 				array(
-					'data'    => $attributes,
-					'content' => $content,
-					'block'   => $this,
+					'data'       => $attributes,
+					'content'    => $content,
+					'block'      => $this,
+					'align'      => $attributes['align'],
+					'is_preview' => $is_preview,
+					'post_id'    => $post_id,
 				),
 				true
 			);


### PR DESCRIPTION
- ACF gives the possibility to get `is_preview` and `post_id` in the render call back https://www.advancedcustomfields.com/resources/acf_register_block_type/
- Also added block align as property