### PR TITLE
get post object function

### DIFF
--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -20,7 +20,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Define $_post.
 	 *
-	 * @var array|null|WP_Post
+	 * @var null|WP_Post
 	 */
 	protected $_post;
 
@@ -63,6 +63,15 @@ class Clarkson_Object implements \JsonSerializable {
 		if ( in_array( $name, array( 'post_name', 'post_title', 'ID', 'post_author', 'post_type', 'post_status' ), true ) ) {
 			throw new Exception( 'Trying to access wp_post object properties from Post object' );
 		}
+	}
+
+	/**
+	 * Get the WordPress post object.
+	 *
+	 * @return null|WP_Post The post object.
+	 */
+	public function get_object(): ?WP_Post {
+		return $this->_post;
 	}
 
 	/**


### PR DESCRIPTION
Adds get_object function to Clarkson_Object to get the WordPress WP_Post object.

Also removed array type from _post variable as this was not a type returned.
Array is only returned if we specify that in the get_post function, which we don't.