### PR TITLE
Simplify get objects

### DIFF
--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -146,7 +146,7 @@ class Clarkson_Core_Objects {
 		// Check if post has a custom template, if so, overwrite value.
 		$page_template_slug = $cc->autoloader->get_template_filename( $post->ID );
 
-		if ( $page_template_slug && ! empty( $page_template_slug ) ) {
+		if ( ! empty( $page_template_slug ) ) {
 			$type = $page_template_slug;
 		}
 
@@ -199,12 +199,9 @@ class Clarkson_Core_Objects {
 		}
 
 		if ( ( in_array( $type, $cc->autoloader->post_types, true ) || in_array( $type, $cc->autoloader->extra, true ) ) && class_exists( $type ) ) {
-			$object = new $type( $post );
-		} else {
-			$object = new Clarkson_Object( $post );
+			return new $type( $post );
 		}
-
-		return $object;
+		return new Clarkson_Object( $post );
 	}
 
 	/**

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -111,15 +111,8 @@ class Clarkson_Core_Objects {
 	public function get_objects( $posts ) {
 		$objects = array();
 
-		if ( empty( $posts ) ) {
-			return $objects;
-		}
-
 		foreach ( $posts as $post ) {
-			$object = $this->get_object( $post );
-			if ( ! empty( $object ) ) {
-				$objects[] = $this->get_object( $post );
-			}
+			$objects[] = $this->get_object( $post );
 		}
 
 		return $objects;

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,0 +1,41 @@
+<?php
+
+class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
+	public function setUp():void {
+		\WP_Mock::setUp();
+	}
+
+	public function tearDown():void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_can_get_instance() {
+		\WP_Mock::userFunction( 'get_template_directory', '/tmp/wp-content/themes/theme/' );
+		$cc_templates = \Clarkson_Core_Objects::get_instance();
+		$this->assertInstanceOf( \Clarkson_Core_Objects::class, $cc_templates );
+		return $cc_templates;
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_objects( $cc_objects ) {
+		$post     = Mockery::mock( '\WP_Post' );
+		$post->ID = 1;
+		\WP_Mock::userFunction( 'get_post_type', 'post' );
+		\WP_Mock::userFunction( 'get_page_template_slug', '' );
+		$this->assertContainsOnlyInstancesOf( \Clarkson_Object::class, $cc_objects->get_objects( array( $post ) ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_term( $cc_objects ) {
+		$term           = Mockery::mock( '\WP_Term' );
+		$term->term_id  = 1;
+		$term->taxonomy = 'category';
+		\WP_Mock::userFunction( 'get_term_by' )->andReturn( $term );
+		\WP_Mock::userFunction( 'get_term' )->andReturn( $term );
+		$this->assertInstanceOf( \Clarkson_Term::class, $cc_objects->get_term( $term ) );
+	}
+}


### PR DESCRIPTION
`get_object` and `get_objects` was needlessly complex.