### PR TITLE
Simplify user interface

### DIFF
--- a/lib/clarkson-core-autoloader.php
+++ b/lib/clarkson-core-autoloader.php
@@ -131,7 +131,6 @@ class Clarkson_Core_Autoloader {
 			$pathinfo = pathinfo( $page_template_slug );
 			$filename = array_key_exists( 'filename', $pathinfo ) ? $pathinfo['filename'] : '';
 		}
-
 		return $filename;
 	}
 

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -263,13 +263,15 @@ class Clarkson_Core_Objects {
 	}
 
 	/**
-	 *  Clone.
+	 * Clone.
+	 * @codeCoverageIgnore
 	 */
 	private function __clone() {
 	}
 
 	/**
 	 * Wakeup.
+	 * @codeCoverageIgnore
 	 */
 	private function __wakeup() {
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/../clarkson-core.php';
 class WP_Block_Type{}
 
 /**
- * Test class for custom user role casting.
+ * Test classes for custom type castings.
  */
 class user_test_role extends \Clarkson_User{}; //phpcs:ignore
+class custom_test_tax extends \Clarkson_Term{}; //phpcs:ignore

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,8 @@ WP_Mock::bootstrap();
  */
 require_once __DIR__ . '/../clarkson-core.php';
 
+require_once __DIR__ . '/custom_test_template.php';
+
 /**
  * Needs to be initialised for the unit test, otherwise it fails on a
  * missing class.
@@ -22,3 +24,4 @@ class WP_Block_Type{}
  */
 class user_test_role extends \Clarkson_User{}; //phpcs:ignore
 class custom_test_tax extends \Clarkson_Term{}; //phpcs:ignore
+class test_overwritten_object_creation extends \Clarkson_Object{}; //phpcs:ignore

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,3 +16,8 @@ require_once __DIR__ . '/../clarkson-core.php';
  * missing class.
  */
 class WP_Block_Type{}
+
+/**
+ * Test class for custom user role casting.
+ */
+class user_test_role extends \Clarkson_User{}; //phpcs:ignore

--- a/tests/custom_test_template.php
+++ b/tests/custom_test_template.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * This file is used to test cutom templated objects.
+ */
+class custom_test_template extends \Clarkson_Object{}; //phpcs:ignore

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use WP_Mock\Functions;
+
 class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	public function setUp():void {
 		\WP_Mock::setUp();
@@ -25,6 +27,55 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		\WP_Mock::userFunction( 'get_post_type', 'post' );
 		\WP_Mock::userFunction( 'get_page_template_slug', '' );
 		$this->assertContainsOnlyInstancesOf( \Clarkson_Object::class, $cc_objects->get_objects( array( $post ) ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_object_with_fallback( $cc_objects ) {
+		$post     = Mockery::mock( '\WP_Post' );
+		$post->ID = 1;
+		\WP_Mock::userFunction( 'get_post' )->andReturn( $post );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_post_type', 'post' );
+		\WP_Mock::userFunction( 'get_page_template_slug', '' );
+		$this->assertInstanceOf( \Clarkson_Object::class, $cc_objects->get_object( 1 ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_object_with_class_creation_overwrite( $cc_objects ) {
+		$post     = Mockery::mock( '\WP_Post' );
+		$post->ID = 1;
+
+		$creation_callback = function() use ( $post ) {
+			return new \test_overwritten_object_creation( $post );
+		};
+
+		\WP_Mock::onFilter( 'clarkson_core_create_object_callback' )
+		->with( false, '', 1 )
+		->reply( $creation_callback );
+
+		\WP_Mock::userFunction( 'get_post' )->andReturn( $post );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_post_type', 'post' );
+		\WP_Mock::userFunction( 'get_page_template_slug', '' );
+		$this->assertInstanceOf( \Clarkson_Object::class, $cc_objects->get_object( 1 ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_custom_page_template( $cc_objects ) {
+		$post     = Mockery::mock( '\WP_Post' );
+		$post->ID = 1;
+		\WP_Mock::userFunction( 'get_post_type', 'page' );
+		\WP_Mock::userFunction( 'get_page_template_slug' )->andReturn( 'custom_test_template.php' );
+
+		$cc                         = Clarkson_Core::get_instance();
+		$cc->autoloader->post_types = array( 'custom_test_template' );
+		$this->assertContainsOnlyInstancesOf( \custom_test_template::class, $cc_objects->get_objects( array( $post ) ) );
 	}
 
 	/**
@@ -60,7 +111,7 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		$cc                         = Clarkson_Core::get_instance();
 		$cc->autoloader->taxonomies = array( 'custom_test_tax' );
 		$this->assertInstanceOf( \custom_test_tax::class, $cc_objects->get_term( $term ) );
-	}	
+	}
 
 	/**
 	 * @depends test_can_get_instance
@@ -132,5 +183,12 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		$cc                         = Clarkson_Core::get_instance();
 		$cc->autoloader->user_types = array( 'user_test_role' );
 		$this->assertInstanceOf( \user_test_role::class, $cc_objects->get_user( $user ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_available_objects( $cc_objects ) {
+		$this->assertIsArray( $cc_objects->available_objects() );
 	}
 }

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -38,4 +38,76 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		\WP_Mock::userFunction( 'get_term' )->andReturn( $term );
 		$this->assertInstanceOf( \Clarkson_Term::class, $cc_objects->get_term( $term ) );
 	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_users( $cc_objects ) {
+		$user        = Mockery::mock( '\WP_User' );
+		$user->roles = array( 'administrator' );
+		$this->assertContainsOnlyInstancesOf( \Clarkson_User::class, $cc_objects->get_users( array( $user ) ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_users_with_id_fallback( $cc_objects ) {
+		$user        = Mockery::mock( '\WP_User' );
+		$user->roles = array( 'administrator' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( 1 )->andReturn( $user );
+		$this->assertContainsOnlyInstancesOf( \Clarkson_User::class, $cc_objects->get_users( array( 1 ) ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_throw_get_users_with_invalid_user_id( $cc_objects ) {
+		$this->expectException( '\Exception' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( -1 )->andReturn( false );
+		$this->assertContainsOnlyInstancesOf( \Clarkson_User::class, $cc_objects->get_users( array( -1 ) ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_user_with_id_fallback( $cc_objects ) {
+		$user        = Mockery::mock( '\WP_User' );
+		$user->roles = array( 'administrator' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( 1 )->andReturn( $user );
+		$this->assertInstanceOf( \Clarkson_User::class, $cc_objects->get_user( 1 ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_throw_get_user_with_invalid( $cc_objects ) {
+		$this->expectException( '\Exception' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( -1 )->andReturn( false );
+		$this->assertInstanceOf( \Clarkson_User::class, $cc_objects->get_user( -1 ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_throw_get_user_with_empty( $cc_objects ) {
+		$this->expectException( '\Exception' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		$this->assertInstanceOf( \Clarkson_User::class, $cc_objects->get_user( '' ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_casts_user_to_custom_object( $cc_objects ) {
+		$user        = Mockery::mock( '\WP_User' );
+		$user->roles = array( 'test_role' );
+
+		$cc                         = Clarkson_Core::get_instance();
+		$cc->autoloader->user_types = array( 'user_test_role' );
+		$this->assertInstanceOf( \user_test_role::class, $cc_objects->get_user( $user ) );
+	}
 }

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -42,6 +42,29 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	/**
 	 * @depends test_can_get_instance
 	 */
+	public function test_can_get_term_invalid( $cc_objects ) {
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		$this->assertFalse( $cc_objects->get_term( 'not_a_valid_term' ) );
+	}
+
+	/**
+	 * @depends test_can_get_instance
+	 */
+	public function test_can_get_term_cast_to_custom_object( $cc_objects ) {
+		$term           = Mockery::mock( '\WP_Term' );
+		$term->term_id  = 1;
+		$term->taxonomy = 'custom_test_tax';
+		\WP_Mock::userFunction( 'get_term_by' )->andReturn( $term );
+		\WP_Mock::userFunction( 'get_term' )->andReturn( $term );
+
+		$cc                         = Clarkson_Core::get_instance();
+		$cc->autoloader->taxonomies = array( 'custom_test_tax' );
+		$this->assertInstanceOf( \custom_test_tax::class, $cc_objects->get_term( $term ) );
+	}	
+
+	/**
+	 * @depends test_can_get_instance
+	 */
 	public function test_can_get_users( $cc_objects ) {
 		$user        = Mockery::mock( '\WP_User' );
 		$user->roles = array( 'administrator' );

--- a/tests/wordpress-objects/Clarkson_User.test.php
+++ b/tests/wordpress-objects/Clarkson_User.test.php
@@ -1,0 +1,41 @@
+<?php
+
+class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
+	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+	public function setUp():void {
+		\WP_Mock::setUp();
+	}
+
+	public function tearDown():void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_can_construct_a_user() {
+		$user   = Mockery::mock( '\WP_User' );
+		$object = new \Clarkson_User( $user );
+		$this->assertInstanceOf( \Clarkson_User::class, $object );
+		return $object;
+	}
+
+	public function test_can_construct_a_user_with_fallback() {
+		$user        = Mockery::mock( '\WP_User' );
+		$user->roles = array( 'administrator' );
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( 1 )->andReturn( $user );
+		$object = new \Clarkson_User( 1 );
+		$this->assertInstanceOf( \Clarkson_User::class, $object );
+	}
+
+	public function test_throw_construct_user_with_invalid_id() {
+		\WP_Mock::userFunction( '_doing_it_wrong' );
+		\WP_Mock::userFunction( 'get_userdata' )->with( -1 )->andReturn( false );
+		$this->expectException( '\Exception' );
+		new \Clarkson_User( -1 );
+	}
+
+	public function test_throw_construct_user_with_empty() {
+		$this->expectException( '\Exception' );
+		new \Clarkson_User( '' );
+	}
+}

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -404,7 +404,11 @@ class Clarkson_Object implements \JsonSerializable {
 	public function get_author() {
 
 		if ( $this->_post->post_author ) {
-			return Clarkson_User::get( $this->_post->post_author );
+			try {
+				return Clarkson_User::get( $this->_post->post_author );
+			} catch ( \Exception $e ) {
+				return null;
+			}
 		}
 
 		return null;

--- a/wordpress-objects/Clarkson_User.php
+++ b/wordpress-objects/Clarkson_User.php
@@ -9,6 +9,13 @@
  * Object oriented wrapper for WP_User objects.
  */
 class Clarkson_User {
+	/**
+	 * WordPress representation of this user object.
+	 *
+	 * @var \WP_User
+	 */
+	protected $_user;
+
 
 	/**
 	 * Current user.
@@ -16,10 +23,11 @@ class Clarkson_User {
 	 * @var \WP_User $_current_user
 	 */
 	protected static $_current_user;
+
 	/**
 	 * Users.
 	 *
-	 * @var object $users
+	 * @var static[] $users
 	 */
 	protected static $users;
 
@@ -43,31 +51,37 @@ class Clarkson_User {
 	 *
 	 * @param  int $id User id.
 	 * @return \Clarkson_User
+	 * @throws \Exception In case a requested user ID does not exist.
 	 */
 	public static function get( $id ) {
-		if ( ! isset( static::$users[ $id ] ) ) {
-			$class                = get_called_class();
-			static::$users[ $id ] = new $class( $id );
+		$user = get_userdata( $id );
+		if ( ! $user instanceof \WP_User ) {
+			throw new Exception( "User not found ($id)" );
 		}
 
-		return static::$users[ $id ];
+		return \Clarkson_Core_Objects::get_instance()->get_user( $user );
 	}
 
 	/**
 	 * Clarkson_User constructor.
 	 *
-	 * @param  int $user_id User id.
+	 * @param  \WP_User|int $user WP_User object (or deprecated User id).
 	 * @throws Exception          User status.
 	 */
-	public function __construct( $user_id ) {
-		if ( empty( $user_id ) ) {
-			throw new Exception( $user_id . ' empty' );
-		}
+	public function __construct( $user ) {
+		if ( $user instanceof \WP_User ) {
+			$this->_user = $user;
+		} else {
+			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Supply a \WP_User object or use \'::get(user_id)\' instead.', '0.5.0' );
+			if ( empty( $user ) ) {
+				throw new Exception( $user . ' empty' );
+			}
 
-		$this->_id = $user_id;
-
-		if ( ! $this->get_user() ) {
-			throw new Exception( $user_id . ' does not exist' );
+			$user_object = $this->get_user();
+			if ( ! $user instanceof \WP_User ) {
+				throw new Exception( $user . ' does not exist' );
+			}
+			$this->_user = $user_object;
 		}
 	}
 
@@ -83,18 +97,9 @@ class Clarkson_User {
 	/**
 	 * Get the WordPress WP_User object.
 	 *
-	 * @return null|\WP_User
+	 * @return \WP_User
 	 */
 	public function get_user() {
-		if ( ! isset( $this->_user ) ) {
-			$this->_user = new WP_User( $this->_id );
-		}
-
-		if ( ! $this->_user->ID ) {
-			unset( $this->_user );
-			return null;
-		}
-
 		return $this->_user;
 	}
 
@@ -104,7 +109,7 @@ class Clarkson_User {
 	 * @return int User id.
 	 */
 	public function get_id() {
-		return $this->_id;
+		return $this->_user->ID;
 	}
 
 	/**

--- a/wordpress-objects/Clarkson_User.php
+++ b/wordpress-objects/Clarkson_User.php
@@ -77,8 +77,8 @@ class Clarkson_User {
 				throw new Exception( $user . ' empty' );
 			}
 
-			$user_object = $this->get_user();
-			if ( ! $user instanceof \WP_User ) {
+			$user_object = get_userdata( $user );
+			if ( ! $user_object instanceof \WP_User ) {
 				throw new Exception( $user . ' does not exist' );
 			}
 			$this->_user = $user_object;


### PR DESCRIPTION
All User creation function now prefer a `\WP_User` object instead of an ID. Before, creating an object with an ID resulted in unexpected behaviour, such as a `Clarkson_User` without an actual user object. Also we now always cast to the correct `custom_role` object, regardless of creation method.

The old way of creating objects is still available but discouraged with a `_doing_it_wrong` notice.

This changeset also contains some additional tests. With this change the `Clarkson_Core_Objects` class is 100% covered :tada: 