### PR TITLE
Psalm fixes

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -22,6 +22,13 @@
 class Clarkson_Core {
 
 	/**
+	 * Container for autoloadable files.
+	 * 
+	 * @var Clarkson_Core_Autoloader
+	 */
+	public $autoloader;
+
+	/**
 	 * Initializes all neccessery objects. Is automatically called on 'init'.
 	 *
 	 * Should not be called manually. This method is public because it needs to be

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -23,7 +23,7 @@ class Clarkson_Core {
 
 	/**
 	 * Container for autoloadable files.
-	 * 
+	 *
 	 * @var Clarkson_Core_Autoloader
 	 */
 	public $autoloader;

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -34,12 +34,12 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_Term $term The term.
 	 *
-	 * @return bool|\Clarkson_Term
+	 * @return \Clarkson_Term
 	 */
 	public function get_term( $term ) {
 		if ( ! $term instanceof \WP_Term ) {
-			_doing_it_wrong( __METHOD__, 'You must call this function with a valid \WP_Term object', '0.1.0' );
-			return false;
+			_doing_it_wrong( __METHOD__, 'You must call this function with a valid \WP_Term object.', '0.1.0' );
+			throw new Exception( 'You must call this function with a valid \WP_Term object.' );
 		}
 
 		$cc         = Clarkson_Core::get_instance();

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -400,7 +400,7 @@ class Clarkson_Core_Templates {
 		$theme = wp_get_theme();
 
 		if ( method_exists( $theme, 'get_page_templates' ) ) {
-			if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', 'lt' ) ) { // 4.6 and older
+			if ( version_compare( get_bloginfo( 'version' ), '4.7', 'lt' ) ) { // 4.6 and older
 				$templates = $theme->get_page_templates();
 			} else { // 4.7+
 				$templates = array();
@@ -616,7 +616,7 @@ class Clarkson_Core_Templates {
 		add_filter( 'acf/location/rule_values/page_template', array( $this, 'get_templates' ) );
 
 		// Add a filter to the attributes metabox to inject template into the cache.
-		if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', 'lt' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '4.7', 'lt' ) ) {
 			// WP 4.6 and older.
 			add_filter( 'page_attributes_dropdown_pages_args', array( $this, 'register_custom_templates' ) );
 		} else {

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -400,7 +400,7 @@ class Clarkson_Core_Templates {
 		$theme = wp_get_theme();
 
 		if ( method_exists( $theme, 'get_page_templates' ) ) {
-			if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', '<' ) ) { // 4.6 and older
+			if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', 'lt' ) ) { // 4.6 and older
 				$templates = $theme->get_page_templates();
 			} else { // 4.7+
 				$templates = array();
@@ -616,7 +616,7 @@ class Clarkson_Core_Templates {
 		add_filter( 'acf/location/rule_values/page_template', array( $this, 'get_templates' ) );
 
 		// Add a filter to the attributes metabox to inject template into the cache.
-		if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', '<' ) ) {
+		if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', 'lt' ) ) {
 			// WP 4.6 and older.
 			add_filter( 'page_attributes_dropdown_pages_args', array( $this, 'register_custom_templates' ) );
 		} else {

--- a/lib/clarkson-core-twig-extension.php
+++ b/lib/clarkson-core-twig-extension.php
@@ -963,7 +963,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 	/**
 	 * Get the Twig functions.
 	 *
-	 * @return array|Twig_SimpleFunction[] $twig_functions Twig functions.
+	 * @return Twig_SimpleFunction[] $twig_functions Twig functions.
 	 * @internal
 	 */
 	public function getFunctions() {

--- a/psalm.xml
+++ b/psalm.xml
@@ -108,7 +108,7 @@
 
         <!-- level 6 issues - really bad things -->
 
-        <InvalidNullableReturnType errorLevel="info" />
+        <InvalidNullableReturnType errorLevel="error" />
         <NullableReturnStatement errorLevel="info" />
         <InvalidFalsableReturnType errorLevel="info" />
         <FalsableReturnStatement errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -94,9 +94,9 @@
 
         <!-- level 5 issues - should be avoided at mosts costs... -->
 
-        <ForbiddenCode errorLevel="info" />
-        <ImplicitToStringCast errorLevel="info" />
-        <InvalidScalarArgument errorLevel="info" />
+        <ForbiddenCode errorLevel="error" />
+        <ImplicitToStringCast errorLevel="error" />
+        <InvalidScalarArgument errorLevel="error" />
         <InvalidToString errorLevel="info" />
         <InvalidOperand errorLevel="info" />
         <NoInterfaceProperties errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -104,7 +104,7 @@
         <TypeDoesNotContainType errorLevel="error" />
         <TypeDoesNotContainNull errorLevel="error" />
         <MissingDocblockType errorLevel="error" />
-        <ImplementedReturnTypeMismatch errorLevel="info" />
+        <ImplementedReturnTypeMismatch errorLevel="error" />
 
         <!-- level 6 issues - really bad things -->
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -109,12 +109,12 @@
         <!-- level 6 issues - really bad things -->
 
         <InvalidNullableReturnType errorLevel="error" />
-        <NullableReturnStatement errorLevel="info" />
-        <InvalidFalsableReturnType errorLevel="info" />
-        <FalsableReturnStatement errorLevel="info" />
+        <NullableReturnStatement errorLevel="error" />
+        <InvalidFalsableReturnType errorLevel="error" />
+        <FalsableReturnStatement errorLevel="error" />
 
-        <MoreSpecificImplementedParamType errorLevel="info" />
-        <LessSpecificImplementedReturnType errorLevel="info" />
+        <MoreSpecificImplementedParamType errorLevel="error" />
+        <LessSpecificImplementedReturnType errorLevel="error" />
 
         <InvalidReturnStatement errorLevel="info" />
         <InvalidReturnType errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -99,11 +99,11 @@
         <InvalidScalarArgument errorLevel="error" />
         <InvalidToString errorLevel="error" />
         <InvalidOperand errorLevel="error" />
-        <NoInterfaceProperties errorLevel="info" />
-        <TooManyArguments errorLevel="info" />
-        <TypeDoesNotContainType errorLevel="info" />
-        <TypeDoesNotContainNull errorLevel="info" />
-        <MissingDocblockType errorLevel="info" />
+        <NoInterfaceProperties errorLevel="error" />
+        <TooManyArguments errorLevel="suppress" />
+        <TypeDoesNotContainType errorLevel="error" />
+        <TypeDoesNotContainNull errorLevel="error" />
+        <MissingDocblockType errorLevel="error" />
         <ImplementedReturnTypeMismatch errorLevel="info" />
 
         <!-- level 6 issues - really bad things -->

--- a/psalm.xml
+++ b/psalm.xml
@@ -131,11 +131,11 @@
         <InvalidReturnStatement errorLevel="error" />
         <InvalidReturnType errorLevel="error" />
         <InvalidArgument errorLevel="error" />
-        <InvalidPropertyAssignmentValue errorLevel="info" />
-        <InvalidArrayOffset errorLevel="info" />
-        <InvalidArrayAssignment errorLevel="info" />
-        <InvalidArrayAccess errorLevel="info" />
-        <InvalidClone errorLevel="info" />
+        <InvalidPropertyAssignmentValue errorLevel="error" />
+        <InvalidArrayOffset errorLevel="error" />
+        <InvalidArrayAssignment errorLevel="error" />
+        <InvalidArrayAccess errorLevel="error" />
+        <InvalidClone errorLevel="error" />
 
         <InvalidGlobal errorLevel="suppress" />
     </issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -116,10 +116,10 @@
         <MoreSpecificImplementedParamType errorLevel="error" />
         <LessSpecificImplementedReturnType errorLevel="error" />
 
-        <InvalidReturnStatement errorLevel="info" />
-        <InvalidReturnType errorLevel="info" />
-        <UndefinedThisPropertyAssignment errorLevel="info" />
-        <UndefinedInterfaceMethod errorLevel="info" />
+        <InvalidReturnStatement errorLevel="error" />
+        <InvalidReturnType errorLevel="error" />
+        <UndefinedThisPropertyAssignment errorLevel="error" />
+        <UndefinedInterfaceMethod errorLevel="error" />
 
         <!-- level 7 issues - even worse -->
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -123,8 +123,8 @@
 
         <!-- level 7 issues - even worse -->
 
-        <UndefinedThisPropertyAssignment errorLevel="info" />
-        <UndefinedPropertyAssignment errorLevel="info" />
+        <UndefinedThisPropertyAssignment errorLevel="error" />
+        <UndefinedPropertyAssignment errorLevel="error" />
         <UndefinedThisPropertyFetch errorLevel="info" />
         <UndefinedPropertyFetch errorLevel="info" />
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -125,10 +125,10 @@
 
         <UndefinedThisPropertyAssignment errorLevel="error" />
         <UndefinedPropertyAssignment errorLevel="error" />
-        <UndefinedThisPropertyFetch errorLevel="info" />
-        <UndefinedPropertyFetch errorLevel="info" />
+        <UndefinedThisPropertyFetch errorLevel="error" />
+        <UndefinedPropertyFetch errorLevel="error" />
 
-        <InvalidReturnStatement errorLevel="info" />
+        <InvalidReturnStatement errorLevel="error" />
         <InvalidReturnType errorLevel="info" />
         <InvalidArgument errorLevel="info" />
         <InvalidPropertyAssignmentValue errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -129,8 +129,8 @@
         <UndefinedPropertyFetch errorLevel="error" />
 
         <InvalidReturnStatement errorLevel="error" />
-        <InvalidReturnType errorLevel="info" />
-        <InvalidArgument errorLevel="info" />
+        <InvalidReturnType errorLevel="error" />
+        <InvalidArgument errorLevel="error" />
         <InvalidPropertyAssignmentValue errorLevel="info" />
         <InvalidArrayOffset errorLevel="info" />
         <InvalidArrayAssignment errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -97,8 +97,8 @@
         <ForbiddenCode errorLevel="error" />
         <ImplicitToStringCast errorLevel="error" />
         <InvalidScalarArgument errorLevel="error" />
-        <InvalidToString errorLevel="info" />
-        <InvalidOperand errorLevel="info" />
+        <InvalidToString errorLevel="error" />
+        <InvalidOperand errorLevel="error" />
         <NoInterfaceProperties errorLevel="info" />
         <TooManyArguments errorLevel="info" />
         <TypeDoesNotContainType errorLevel="info" />

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -95,7 +95,8 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_can_get_term_invalid( $cc_objects ) {
 		\WP_Mock::userFunction( '_doing_it_wrong' );
-		$this->assertFalse( $cc_objects->get_term( 'not_a_valid_term' ) );
+		$this->expectException( '\Exception' );
+		$cc_objects->get_term( 'not_a_valid_term' );
 	}
 
 	/**

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -41,7 +41,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Define $posts.
 	 *
-	 * @var $posts
+	 * @var Clarkson_Object[] $posts
 	 */
 	protected static $posts;
 

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -230,7 +230,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Get the thumbnail id by post id.
 	 *
-	 * @return string The ID of the post, or an empty string on failure.
+	 * @return string|int The ID of the post, or an empty string on failure.
 	 */
 	public function get_thumbnail_id() {
 		return get_post_thumbnail_id( $this->get_id() );

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -63,12 +63,12 @@ class Clarkson_Object implements \JsonSerializable {
 			}
 
 			$post_object = get_post( $post );
-			if(! $post_object instanceof WP_Post){
+			if ( ! $post_object instanceof WP_Post ) {
 				throw new Exception( '$post empty' );
 			}
 
-			$this->_post = $post_object; 
-			
+			$this->_post = $post_object;
+
 		}
 	}
 

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -425,7 +425,7 @@ class Clarkson_Object implements \JsonSerializable {
 
 		if ( $this->_post->post_author ) {
 			try {
-				return Clarkson_User::get( $this->_post->post_author );
+				return Clarkson_User::get( (int) $this->_post->post_author );
 			} catch ( \Exception $e ) {
 				return null;
 			}

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -534,7 +534,7 @@ class Clarkson_Object implements \JsonSerializable {
 		$result = wp_insert_comment( $comment );
 
 		if ( ! is_numeric( $result ) ) {
-			throw new Exception( 'wp_insert_post failed: ' . $result );
+			throw new Exception( 'wp_insert_comment failed: ' . $comment_text );
 		}
 
 		return $result;

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -20,7 +20,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Define $_post.
 	 *
-	 * @var null|WP_Post
+	 * @var WP_Post
 	 */
 	protected $_post;
 
@@ -62,7 +62,13 @@ class Clarkson_Object implements \JsonSerializable {
 				throw new Exception( '$post empty' );
 			}
 
-			$this->_post = get_post( $post );
+			$post_object = get_post( $post );
+			if(! $post_object instanceof WP_Post){
+				throw new Exception( '$post empty' );
+			}
+
+			$this->_post = $post_object; 
+			
 		}
 	}
 

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -25,6 +25,20 @@ class Clarkson_Object implements \JsonSerializable {
 	protected $_post;
 
 	/**
+	 * Microcache for parsed post content.
+	 *
+	 * @var null|string
+	 */
+	protected $_content;
+
+	/**
+	 * Microcache for parsed post excerpt.
+	 *
+	 * @var null|string
+	 */
+	protected $_excerpt;
+
+	/**
 	 * Define $posts.
 	 *
 	 * @var $posts

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -262,7 +262,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 * @return string
 	 */
 	public function get_date_i18n( $format = 'U', $gmt = false ) {
-		return date_i18n( $format, strtotime( $this->_post->post_date_gmt, $gmt ) );
+		return date_i18n( $format, strtotime( $this->_post->post_date_gmt ), $gmt );
 	}
 
 	/**

--- a/wordpress-objects/Clarkson_Term.php
+++ b/wordpress-objects/Clarkson_Term.php
@@ -86,7 +86,7 @@ class Clarkson_Term {
 	 */
 	public function __construct( $term, $taxonomy = null ) {
 		if ( $term instanceof \WP_Term ) {
-			$this->term = $term;
+			$this->_term = $term;
 		} else {
 			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Use \'::get_by_id(term_id)\' instead.', '0.2.0' );
 			$taxonomy = $taxonomy ?: static::$taxonomy;
@@ -97,7 +97,7 @@ class Clarkson_Term {
 			if ( ! $term_result instanceof WP_Term ) {
 				throw new Exception( "Term not found ($taxonomy:$term)" );
 			}
-			$this->term = $term_result;
+			$this->_term = $term_result;
 		}
 	}
 

--- a/wordpress-objects/Clarkson_User.php
+++ b/wordpress-objects/Clarkson_User.php
@@ -210,7 +210,7 @@ class Clarkson_User {
 	 * @param string       $key   User meta key.
 	 * @param array|string $value User meta data.
 	 *
-	 * @return bool
+	 * @return int|false
 	 */
 	public function add_meta( $key, $value ) {
 		return add_user_meta( $this->get_id(), $key, $value );


### PR DESCRIPTION
I've run the psalm test implemented earlier with all rules up to level 5 as errors, instead of warnings. 

It caught some interesting bugs, and overall makes for a more robust typing system. It should be enabled with errors at this level from now on. 