### PR TITLE
Fix for always loading role, [0] can be empty.

### DIFF
--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -99,7 +99,10 @@ class Clarkson_Core_Objects {
 		$class_name = false;
 
 		if ( $user->roles && count( $user->roles ) >= 1 ) {
-			$class_name = $cc->autoloader->user_objectname_prefix . $user->roles[0];
+			// get the first role in the array.
+			$roles      = array_reverse( $user->roles );
+			$role       = array_pop( $roles );
+			$class_name = $cc->autoloader->user_objectname_prefix . $role;
 		}
 
 		if ( $class_name && in_array( $class_name, $cc->autoloader->user_types, true ) && class_exists( $class_name ) ) {


### PR DESCRIPTION
In the event of a user that had multiple roles and the first one gets removed [0] will be empty. This is a possible fix for this issue.