### PR TITLE
Template hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /node_modules
 /out
+/.vscode/

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:  Clarkson Core
- * Version:      0.4.3
+ * Version:      1.0.0
  * Plugin URI:   http://wp-clarkson.com/core
  * Description:  A mu-plugin to write Object-Oriented code in combination with the Twig templating engine while keeping the WordPress Way of working in mind.
  * Author:       Level Level

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -63,7 +63,7 @@ class Clarkson_Core_Objects {
 
 		foreach ( $users as $user ) {
 			if ( ! $user instanceof \WP_User ) {
-				_doing_it_wrong( __METHOD__, 'Deprecated get_user called with an ID. Supply a \WP_User object or use \'Clarkson_User::get(user_id)\' instead.', '0.5.0' );
+				_doing_it_wrong( __METHOD__, 'Deprecated get_user called with an ID. Supply a \WP_User object or use \'Clarkson_User::get(user_id)\' instead.', '1.0.0' );
 				$user_id = $user;
 				$user    = get_userdata( $user_id );
 				if ( ! $user instanceof \WP_User ) {
@@ -85,7 +85,7 @@ class Clarkson_Core_Objects {
 	 */
 	public function get_user( $user ) {
 		if ( ! $user instanceof \WP_User ) {
-			_doing_it_wrong( __METHOD__, 'Deprecated get_user called with an ID. Supply a \WP_User object or use \'Clarkson_User::get(user_id)\' instead.', '0.5.0' );
+			_doing_it_wrong( __METHOD__, 'Deprecated get_user called with an ID. Supply a \WP_User object or use \'Clarkson_User::get(user_id)\' instead.', '1.0.0' );
 			$user_id = $user;
 			if ( empty( $user_id ) ) {
 				throw new Exception( $user_id . ' does not exist' );
@@ -137,7 +137,7 @@ class Clarkson_Core_Objects {
 	 */
 	public function get_object( $post ) {
 		if ( ! $post instanceof WP_Post && is_int( (int) $post ) ) {
-			_doing_it_wrong( __METHOD__, 'Deprecated calling of get_object with an ID. Use a `WP_Post` instead', '0.5.0' );
+			_doing_it_wrong( __METHOD__, 'Deprecated calling of get_object with an ID. Use a `WP_Post` instead', '1.0.0' );
 			$post = get_post( $post );
 		}
 

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -44,14 +44,7 @@ class Clarkson_Core_Templates {
 			}
 		}
 
-		if ( isset( $wp_query->query_vars['json'] ) ) {
-			if ( count( $objects ) === 1 && isset( $objects['objects'][0] ) ) {
-				$objects = reset( $objects['objects'][0] );
-			}
-			$this->echo_json( $objects );
-		} else {
-			$this->echo_twig( $path, $objects, $ignore_warning );
-		}
+		$this->echo_twig( $path, $objects, $ignore_warning );
 		exit();
 	}
 
@@ -140,43 +133,6 @@ class Clarkson_Core_Templates {
 	 */
 	public function echo_twig( $template_file, $objects, $ignore_warning = false ) {
 		echo $this->render_twig( $template_file, $objects, $ignore_warning );
-	}
-
-	/**
-	 * Render Json.
-	 *
-	 * @param array $posts Post or posts.
-	 *
-	 * @see: https://github.com/level-level/Clarkson-Core/issues/125.
-	 *
-	 * @return mixed|string|void
-	 * @deprecated Use the WordPress API instead.
-	 */
-	public function render_json( $posts ) {
-		header( 'Content-Type: application/json' );
-
-		// If single post then create new array.
-		if ( ! is_array( $posts ) ) {
-			$objects[] = $posts;
-		} else {
-			$objects = $posts;
-		}
-
-		$cc_objects = Clarkson_Core_Objects::get_instance();
-		$objects    = $cc_objects->get_objects( $objects );
-		return json_encode( $objects, JSON_PRETTY_PRINT );
-	}
-
-
-	/**
-	 * Echo Json data.
-	 *
-	 * @see https://github.com/level-level/Clarkson-Core/issues/126,
-	 * @param array $objects Posts.
-	 * @deprecated Use the WordPress API instead.
-	 */
-	public function echo_json( $objects ) {
-		echo $this->render_json( $objects );
 	}
 
 	/**

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -9,7 +9,12 @@
  * Allows rendering of specific templates with Twig.
  */
 class Clarkson_Core_Templates {
-	const TEMPLATE_TYPES = array(
+	/**
+	 * The template types, are all seperate `get_query_template` can be called with.
+	 * 
+	 * @see https://developer.wordpress.org/reference/functions/get_query_template/ The code defines the possible `type` values.
+	 */
+	private const TEMPLATE_TYPES = array(
 		'index',
 		'404',
 		'archive',
@@ -110,6 +115,23 @@ class Clarkson_Core_Templates {
 		if ( $debug ) {
 			$twig->addExtension( new Twig_Extension_Debug() );
 		}
+
+		/**
+		 * Allows themes and plugins to edit the Clarkson Twig environment.
+		 *
+		 * @hook clarkson_twig_environment
+		 * @since 1.0.0
+		 * @param {Twig_Environment} $twig Twig environment.
+		 * @return {Twig_Environment} Twig environment.
+		 *
+		 * @example
+		 * // We can add custom twig extensions.
+		 * add_filter( 'clarkson_twig_environment', function( $twig ) {
+		 *  $twig->addExtension( new \Custom_Twig_Extension() );
+		 *  return $twig;
+		 * } );
+		 */
+		$twig = apply_filters( 'clarkson_twig_environment', $twig );
 
 		/**
 		 * Context variables that are available in twig templates.

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -298,7 +298,7 @@ class Clarkson_Core_Templates {
 		$templates      = $choices;
 		$page_templates = array();
 		foreach ( $this->get_template_files() as $name => $path ) {
-			if ( preg_match( '#^template-#i', $name ) === 1 && 'template' !== $name ) {
+			if ( preg_match( '#^template-#i', $name ) === 1 ) {
 				$name                                = str_replace( 'template-', '', $name );
 				$name                                = str_replace( '-', ' ', $name );
 				$name                                = ucwords( $name );

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -36,13 +36,6 @@ class Clarkson_Core_Templates {
 	);
 
 	/**
-	 * Define Templates.
-	 *
-	 * @var array $templates Templates.
-	 */
-	protected $templates = array();
-
-	/**
 	 * Define has_been_called
 	 *
 	 * @var bool $has_been_called Check if template rendering has already been called.

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -11,7 +11,7 @@
 class Clarkson_Core_Templates {
 	/**
 	 * The template types, are all seperate `get_query_template` can be called with.
-	 * 
+	 *
 	 * @see https://developer.wordpress.org/reference/functions/get_query_template/ The code defines the possible `type` values.
 	 */
 	private const TEMPLATE_TYPES = array(
@@ -281,7 +281,7 @@ class Clarkson_Core_Templates {
 				$page_vars['found_posts'] = $wp_query->get( 'filtered_found_posts' ) ? $wp_query->get( 'filtered_found_posts' ) : $wp_query->found_posts;
 			}
 			$page_vars['objects'] = $object_loader->get_objects( $posts );
-			$template = realpath($template);
+			$template             = realpath( $template );
 
 			$this->render( $template, $page_vars, true );
 		}
@@ -302,11 +302,11 @@ class Clarkson_Core_Templates {
 		if ( $templates ) {
 			return $templates;
 		}
-		$templates = $choices;
+		$templates      = $choices;
 		$page_templates = array();
 		foreach ( $this->get_template_files() as $name => $path ) {
 			if ( preg_match( '#^template-#i', $name ) === 1 && 'template' !== $name ) {
-				$name              = str_replace( 'template-', '', $name );
+				$name                                = str_replace( 'template-', '', $name );
 				$name                                = str_replace( '-', ' ', $name );
 				$name                                = ucwords( $name );
 				$page_templates[ basename( $path ) ] = $name;
@@ -380,8 +380,8 @@ class Clarkson_Core_Templates {
 		}
 
 		foreach ( $templates as $template ) {
-			$base      = basename( $template );
-			$base      = str_replace( '.twig', '', $base );
+			$base               = basename( $template );
+			$base               = str_replace( '.twig', '', $base );
 			$templates[ $base ] = $template;
 		}
 		return $templates;
@@ -425,19 +425,21 @@ class Clarkson_Core_Templates {
 		return $instance;
 	}
 
-	public function add_twig_to_template_hierarchy(array $original_templates){
+	public function add_twig_to_template_hierarchy( array $original_templates ) {
 		$templates = array();
 
-		$directories = array_unique(array(
-			str_replace(get_stylesheet_directory(), '', $this->get_stylesheet_dir()),
-			str_replace(get_template_directory(), '', $this->get_template_dir()),
-		));
+		$directories = array_unique(
+			array(
+				str_replace( get_stylesheet_directory(), '', $this->get_stylesheet_dir() ),
+				str_replace( get_template_directory(), '', $this->get_template_dir() ),
+			)
+		);
 
-		foreach($original_templates as $template){
-			$pathinfo = pathinfo($template);
-			foreach($directories as $directory){
+		foreach ( $original_templates as $template ) {
+			$pathinfo = pathinfo( $template );
+			foreach ( $directories as $directory ) {
 				$twig_template = $pathinfo['dirname'] . $directory . '/' . $pathinfo['filename'] . '.twig';
-				$templates[] = $twig_template;
+				$templates[]   = $twig_template;
 			}
 			$templates[] = $template;
 		}
@@ -451,8 +453,8 @@ class Clarkson_Core_Templates {
 		if ( ! class_exists( 'Clarkson_Core_Objects' ) ) {
 			return;
 		}
-		foreach(self::TEMPLATE_TYPES as $template_type){
-			add_filter($template_type . '_template_hierarchy', array($this, 'add_twig_to_template_hierarchy'), 999);
+		foreach ( self::TEMPLATE_TYPES as $template_type ) {
+			add_filter( $template_type . '_template_hierarchy', array( $this, 'add_twig_to_template_hierarchy' ), 999 );
 		}
 
 		add_action( 'template_include', array( $this, 'template_include' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.
 * Removes 'page-' template file name compatibility.
-* Themes that relied on incorrect loading of template files may experience some incompatbility.
+* Themes that relied on incorrect loading of template files may experience some incompatibility.
 * Removes `Clarkson_Object::get_json`, which was deprecated in `0.2.0`.
 * The `Clarkson_Term` and `Clarkson_User` interfaces have changed, and you might now get an Exception, instead of an invalid object.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Clarkson Core ===
 Contributors: level level, jmslbam
 Tags: twig, templating, template engine, templates, oop, wordpress objects
-Requires at least: 4.0
+Requires at least: 4.7
 Tested up to: 4.9.4
-Stable tag: 0.4.2
+Stable tag: 1.0.0
 License: GPL v2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,16 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 
 
 == Changelog ==
+
+= 1.0.0 =
+
+* Now uses the actual WordPress template hierarchy, solving a lot of edge cases around template loading.
+* The twig environment is exposed through the new `clarkson_twig_environment` filter.
+
+Backward incompatible changes:
+* Removes compatibility for WordPress < 4.7.
+* Removes 'page-' template file name compatibility.
+* Themes that relied on incorrect loading of template files may experience some incompatbility.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,11 +26,18 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 
 * Now uses the actual WordPress template hierarchy, solving a lot of edge cases around template loading.
 * The twig environment is exposed through the new `clarkson_twig_environment` filter.
+* Normalises the `Clarkson_User` and `Clarkson_Term` object creation interfaces.
+* Minor docblock typehint improvements in `Clarkson_Object`.
+* Extends parameters available in `Clarkson_Core_Gutenberg_Block_Type::clarkson_render_callback`
+* `Clarkson_Object` has a new `get_object()` method.
+* 
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.
 * Removes 'page-' template file name compatibility.
 * Themes that relied on incorrect loading of template files may experience some incompatbility.
+* Removes `Clarkson_Object::get_json`, which was deprecated in `0.2.0`.
+* The `Clarkson_Term` and `Clarkson_User` interfaces have changed, and you might now get an Exception, instead of an invalid object.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/tests/lib/clarkson-core-templates.test.php
+++ b/tests/lib/clarkson-core-templates.test.php
@@ -17,27 +17,4 @@ class ClarksonCoreTemplatesTest extends \WP_Mock\Tools\TestCase {
 		$this->assertInstanceOf( \Clarkson_Core_Templates::class, $cc_templates );
 		return $cc_templates;
 	}
-
-	/**
-	 * @depends test_can_get_instance
-	 */
-	public function test_can_add_template( $cc_templates ) {
-		$term           = Mockery::mock( '\WP_Term' );
-		$term->taxonomy = 'category';
-		\WP_Mock::userFunction( 'get_queried_object' )->andReturn( $term );
-		\WP_Mock::userFunction( 'current_filter', 'category_template' );
-		\WP_Mock::userFunction( 'get_post_type', null );
-		$this->assertEquals( 'template.twig', $cc_templates->add_template( 'template.twig' ) );
-	}
-
-	/**
-	 * @depends test_can_get_instance
-	 */
-	public function test_can_get_templates( $cc_templates ) {
-		$theme = Mockery::mock( '\WP_Theme' );
-		\WP_Mock::userFunction( 'wp_cache_get' );
-		\WP_Mock::userFunction( 'wp_get_theme' )->andReturn( $theme );
-		\WP_Mock::userFunction( 'wp_cache_set' );
-		$this->assertEquals( array( 'page-alt' ), $cc_templates->get_templates( array( 'page-alt' ) ) );
-	}
 }

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -657,9 +657,8 @@ class Clarkson_Object implements \JsonSerializable {
 	}
 
 	/**
-	 * Return a set of data when calling the /json endpoint.
-	 * If you want something else, then just overwrite it in your own WordPress object.
-	 *
+	 * Return a set of data to use for json output.
+	 * 
 	 * We can't just return $this->_post, because these values will only return raw unfiltered data.
 	 */
 	public function jsonSerialize() {
@@ -686,16 +685,4 @@ class Clarkson_Object implements \JsonSerializable {
 
 		return $data;
 	}
-
-	/**
-	 * Create serialized json file.
-	 *
-	 * @return mixed
-	 * @deprecated
-	 */
-	public function get_json() {
-		_doing_it_wrong( __METHOD__, 'Deprecated directly calling get_json. Just json_encode the object itself, because the Clarkson_Object implements JsonSerializable.', '0.2.0' );
-		return $this->jsonSerialize();
-	}
-
 }

--- a/wordpress-objects/Clarkson_Object.php
+++ b/wordpress-objects/Clarkson_Object.php
@@ -658,7 +658,7 @@ class Clarkson_Object implements \JsonSerializable {
 
 	/**
 	 * Return a set of data to use for json output.
-	 * 
+	 *
 	 * We can't just return $this->_post, because these values will only return raw unfiltered data.
 	 */
 	public function jsonSerialize() {

--- a/wordpress-objects/Clarkson_User.php
+++ b/wordpress-objects/Clarkson_User.php
@@ -72,7 +72,7 @@ class Clarkson_User {
 		if ( $user instanceof \WP_User ) {
 			$this->_user = $user;
 		} else {
-			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Supply a \WP_User object or use \'::get(user_id)\' instead.', '0.5.0' );
+			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Supply a \WP_User object or use \'::get(user_id)\' instead.', '1.0.0' );
 			if ( empty( $user ) ) {
 				throw new Exception( $user . ' empty' );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->

## Description
<!--- Describe your changes in detail -->
This change makes Clarkson Core follow the [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/). Previously Clarkson Core would use it's own implementation to mimic the WordPress template loading, but it would differ in some nuanced situations. Some examples are #145 and #99.

The path are now injected into the regular template discovery of WordPress, which does a `file_exists` on a number of paths. For instance: WordPress generates a list like this:

```php
array(
'template-xyz.php',
'page-slug.php',
'page-id.php',
'single-page.php',
'singular.php'
)
```

We add in the twig templates to check for availability, right before the php template is checked:

```php
array(
'templates/template-xyz.twig',
'template-xyz.php',
'templates/page-slug.twig',
'page-slug.php',
'templates/page-id.twig',
'page-id.php',
'templates/single-page.twig',
'single-page.php',
'templates/singular.twig',
'singular.php'
)
```

Then, when the rendering of the file comes up, we check if it is a .twig file. If it is, Clarkson handles it and exits. If it is not, WordPress handles it as it would in vanilla.

This change also removes compatibility with WordPress <4.7 which was release 4 years ago at this time.

It also removes compatibility with 'page-' prefixed templates, which where deprecated in `0.3.0`.

The twig instance now gets a new filter, which allows themes and plugins to edit the twig environment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally, with a test project, and 2 regular themes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- Breaking change occurs for every theme that 'relied' on the incorrect template hierarchy of Clarkson Core (which should be none). 
- Breaking change occurs for WordPress < 4.7. They will no longer be able to load custom templates for pages.
- Breaking change for all themes using the `page-` prefixed templates method, deprecated in `0.3.0`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
