### PR TITLE
For #130. Extracts object creation from template class.

### DIFF
--- a/lib/clarkson-core-template-context.php
+++ b/lib/clarkson-core-template-context.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Clarkson Core Template Context.
+ *
+ * @package CLARKSON\Lib
+ */
+
+class Clarkson_Core_Template_Context {
+
+	/**
+	 * Register all hooks to add context to the template call.
+	 */
+	public function register_hooks() {
+		add_filter( 'clarkson_core_template_context', array( $this, 'add_author' ), 10, 2 );
+		add_filter( 'clarkson_core_template_context', array( $this, 'add_term' ), 10, 2 );
+		add_filter( 'clarkson_core_template_context', array( $this, 'add_search_count' ), 10, 2 );
+		add_filter( 'clarkson_core_template_context', array( $this, 'add_posts' ), 10, 2 );
+	}
+
+	/**
+	 * Adds an author object if the current request is an author archive.
+	 */
+	public function add_author( array $context, \WP_Query $wp_query ): array {
+		if ( $wp_query->is_author ) {
+			$object_loader = Clarkson_Core_Objects::get_instance();
+			$object        = $wp_query->queried_object;
+			if ( $object instanceof \WP_User ) {
+				$author            = $object_loader->get_user( $object );
+				$context['user']   = $author; // Available for backward compatibility.
+				$context['author'] = $author;
+			}
+		}
+		return $context;
+	}
+
+	/**
+	 * Adds a term if the current request is a term archive.
+	 */
+	public function add_term( array $context, \WP_Query $wp_query ):array {
+		if ( $wp_query->is_tax ) {
+			$object_loader = Clarkson_Core_Objects::get_instance();
+			$term          = $wp_query->queried_object;
+			if ( $term instanceof \WP_Term ) {
+				$context['term'] = $object_loader->get_term( $term );
+			}
+		}
+		return $context;
+	}
+
+	/**
+	 * Adds the search result count if the current request is a search.
+	 */
+	public function add_search_count( array $context, \WP_Query $wp_query ):array {
+		if ( $wp_query->is_search ) {
+			$context['found_posts'] = $wp_query->get( 'filtered_found_posts' ) ? $wp_query->get( 'filtered_found_posts' ) : $wp_query->found_posts;
+		}
+		return $context;
+	}
+
+	/**
+	 * Adds posts to the current context.
+	 */
+	public function add_posts( array $context, \WP_Query $wp_query ):array {
+		$object_loader      = Clarkson_Core_Objects::get_instance();
+		$context['objects'] = $object_loader->get_objects( $wp_query->posts );
+		return $context;
+	}
+}

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -36,6 +36,15 @@ class Clarkson_Core_Templates {
 	);
 
 	/**
+	 * The template context generator.
+	 *
+	 * This object can be used if you want to remove any of the default add_filters.
+	 *
+	 * @var \Clarkson_Core_Template_Context
+	 */
+	public $template_context;
+
+	/**
 	 * Define has_been_called
 	 *
 	 * @var bool $has_been_called Check if template rendering has already been called.
@@ -190,7 +199,7 @@ class Clarkson_Core_Templates {
 		// if no child-theme is used, then these two above are the same.
 		$template_dirs = array_unique( $template_dirs );
 
-		// Ingore template dir if it doesn't exist
+		// Ignore template dir if it doesn't exist
 		$template_dirs = array_filter(
 			$template_dirs,
 			function( $template_dir ) {
@@ -252,31 +261,31 @@ class Clarkson_Core_Templates {
 	 * @internal
 	 */
 	public function template_include( $template ) {
+		global $wp_query;
 		$extension = pathinfo( $template, PATHINFO_EXTENSION );
 
 		if ( 'twig' === $extension ) {
-			// Get template vars.
-			global $posts;
-			$object_loader = Clarkson_Core_Objects::get_instance();
-
-			$page_vars = array();
-
-			if ( is_author() ) {
-				$page_vars['user'] = $object_loader->get_user( get_user_by( 'id', get_queried_object_id() ) );
-			} elseif ( is_tax() ) {
-				$term = get_queried_object();
-				// Custom Taxonomy Templates per Taxonomy type.
-				if ( is_a( $term, 'WP_Term' ) ) {
-					$page_vars['term'] = $object_loader->get_term( $term );
-				}
-			} elseif ( is_search() ) {
-				global $wp_query;
-				$page_vars['found_posts'] = $wp_query->get( 'filtered_found_posts' ) ? $wp_query->get( 'filtered_found_posts' ) : $wp_query->found_posts;
-			}
-			$page_vars['objects'] = $object_loader->get_objects( $posts );
-			$template             = realpath( $template );
-
-			$this->render( $template, $page_vars, true );
+			/**
+			 * Add and modify variables available during the template rendering.
+			 *
+			 * @hook clarkson_core_template_context
+			 * @since 1.0.0
+			 * @param {array} $context The context that will be passed onto the template.
+			 * @param {\WP_Query} $wp_query The current query that is being rendered.
+			 * @return {array} The context that will be passed onto the template.
+			 *
+			 * @example
+			 * // It is possible to add custom variables to the twig context.
+			 * add_filter( 'clarkson_core_template_context', function( $context, $wp_query ) {
+			 *  if( $wp_query->is_tax ){
+			 *   $context['tax_variable'] = true;
+			 *  }
+			 *  return $context
+			 * } );
+			 */
+			$context  = apply_filters( 'clarkson_core_template_context', array(), $wp_query );
+			$template = realpath( $template );
+			$this->render( $template, $context, true );
 		}
 
 		return $template;
@@ -443,12 +452,16 @@ class Clarkson_Core_Templates {
 	 * Clarkson_Core_Templates constructor.
 	 */
 	protected function __construct() {
+		require_once __DIR__ . '/clarkson-core-template-context.php';
 		if ( ! class_exists( 'Clarkson_Core_Objects' ) ) {
 			return;
 		}
 		foreach ( self::TEMPLATE_TYPES as $template_type ) {
 			add_filter( $template_type . '_template_hierarchy', array( $this, 'add_twig_to_template_hierarchy' ), 999 );
 		}
+
+		$this->template_context = new Clarkson_Core_Template_Context();
+		$this->template_context->register_hooks();
 
 		add_action( 'template_include', array( $this, 'template_include' ) );
 		add_filter( 'acf/location/rule_values/page_template', array( $this, 'get_templates' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Minor docblock typehint improvements in `Clarkson_Object`.
 * Extends parameters available in `Clarkson_Core_Gutenberg_Block_Type::clarkson_render_callback`
 * `Clarkson_Object` has a new `get_object()` method.
-* 
+* Adds new `clarkson_core_template_context` filter.
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.


### PR DESCRIPTION
This is now a separate class and allows users to easily filter in other object based on the WP_Query.

The rest of #130 has already happened in #183  and #185. 

A new filter `clarkson_core_template_context` has been added, which only runs on the initial template being included. It passes in the WP_Query, so the theme can add context objects as required.

`clarkson_core_template_context` is sometimes preferred over `clarkson_context_args`, as it is only run on the main template. For instance, adding header or footer objects to the context args with `clarkson_context_args` meant these variables would be added/retrieved for *all* template renders, even if they are not about the page. This created overhead while rendering other templates such as a widget or an admin panel.