### PR TITLE
Restructure loading

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run NPM CI
       uses: docker://uniplug/apigen:latest
       with:
-        args: "apigen generate -d out/phpdoc -s lib -s wordpress-objects --access-levels public -o"
+        args: "apigen generate -d out/phpdoc -s src --access-levels public -o"
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -16,6 +16,11 @@
  * @author Level Level
  */
 
+use Clarkson_Core\Autoloader;
+use Clarkson_Core\Gutenberg\Block_Manager;
+use Clarkson_Core\Objects;
+use Clarkson_Core\Templates;
+
 /**
  * The main entry point, responsible for registering all objects and hooks.
  */
@@ -24,7 +29,7 @@ class Clarkson_Core {
 	/**
 	 * Container for autoloadable files.
 	 *
-	 * @var Clarkson_Core_Autoloader
+	 * @var Autoloader
 	 */
 	public $autoloader;
 
@@ -38,20 +43,14 @@ class Clarkson_Core {
 	 */
 	public function init() {
 		// Load post objects.
-		if ( class_exists( 'Clarkson_Core_Objects' ) ) {
-			Clarkson_Core_Objects::get_instance();
-		}
+		Objects::get_instance();
 
 		// Load template routing.
-		if ( class_exists( 'Clarkson_Core_Templates' ) ) {
-			Clarkson_Core_Templates::get_instance();
-		}
+		Templates::get_instance();
 
 		// Load template routing.
-		if ( class_exists( 'Clarkson_Core_Gutenberg_Block_Manager' ) ) {
-			$block_manager = new Clarkson_Core_Gutenberg_Block_Manager();
-			$block_manager->init();
-		}
+		$block_manager = new Block_Manager();
+		$block_manager->init();
 	}
 
 	/**
@@ -89,11 +88,7 @@ class Clarkson_Core {
 
 		add_action( 'init', array( $this, 'init' ) );
 
-		if ( ! class_exists( 'Clarkson_Core_Autoloader' ) ) {
-			return;
-		}
-
-		$this->autoloader = new Clarkson_Core_Autoloader();
+		$this->autoloader = new Autoloader();
 	}
 
 	/**

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -40,7 +40,7 @@ class Clarkson_Core {
 	 *
 	 * @internal
 	 */
-	public function init() {
+	public function init():void {
 		// Load post objects.
 		Objects::get_instance();
 
@@ -55,23 +55,19 @@ class Clarkson_Core {
 	/**
 	 * Define instance.
 	 *
-	 * @var Clarkson_Core
+	 * @var null|Clarkson_Core
 	 */
-	protected $instance = null;
+	protected static $instance = null;
 
 	/**
 	 * Setting up the class instance.
-	 *
-	 * @return Clarkson_Core
 	 */
-	public static function get_instance() {
-		static $instance = null;
-
-		if ( null === $instance ) {
-			$instance = new Clarkson_Core();
+	public static function get_instance(): Clarkson_Core {
+		if ( null === self::$instance ) {
+			self::$instance = new Clarkson_Core();
 		}
 
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -16,10 +16,9 @@
  * @author Level Level
  */
 
-use Clarkson_Core\Autoloader;
+namespace Clarkson_Core;
+
 use Clarkson_Core\Gutenberg\Block_Manager;
-use Clarkson_Core\Objects;
-use Clarkson_Core\Templates;
 
 /**
  * The main entry point, responsible for registering all objects and hooks.
@@ -105,4 +104,4 @@ class Clarkson_Core {
 
 }
 
-add_action( 'plugins_loaded', array( 'Clarkson_Core', 'get_instance' ) );
+add_action( 'plugins_loaded', array( Clarkson_Core::class, 'get_instance' ) );

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
 		}
 	],
 	"autoload": {
-	  "classmap": ["wordpress-objects/", "lib/"]
+	  "psr-4": {
+		  "Clarkson_Core\\": "src/"
+	  }
 	},
 	"scripts": {
 		"fix" : [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "doc": "jsdoc -c hookdoc-conf.json ./lib/ ./ ./README.md"
+    "doc": "jsdoc -c hookdoc-conf.json ./src ./ ./README.md"
   },
   "repository": {
     "type": "git",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="clarkson_core">
  <description>Level Level Clarkson Core ruleset</description>
 
- <file>./lib</file>
+ <file>./src</file>
  <file>./tests</file>
  <file>./clarkson-core.php</file>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,6 @@
 
  <file>./lib</file>
  <file>./tests</file>
- <file>./wordpress-objects</file>
  <file>./clarkson-core.php</file>
 
  <!--<arg name="report" value="summary"/>-->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">lib/</directory>
-			<directory suffix=".php">wordpress-objects/</directory>
+			<directory suffix=".php">src/</directory>
 			<file>clarkson-core.php</file>
 		</whitelist>
 	</filter>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    allowStringToStandInForClass="true"
 >
     <projectFiles>
         <directory name="./" />
@@ -16,127 +17,6 @@
         <file name="vendor/giacocorsiglia/wordpress-stubs/wordpress-stubs.php" />
     </stubs>
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
-
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-
-        <RedundantCondition errorLevel="info" />
-
-        <DocblockTypeContradiction errorLevel="info" />
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <UnresolvableInclude errorLevel="info" />
-
-        <RawObjectIteration errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
-
-        <!-- level 4 issues - points to possible deficiencies in logic, higher false-positives -->
-
-        <MoreSpecificReturnType errorLevel="info" />
-        <LessSpecificReturnStatement errorLevel="info" />
-        <TypeCoercion errorLevel="info" />
-
-        <PossiblyFalseArgument errorLevel="info" />
-        <PossiblyFalseIterator errorLevel="info" />
-        <PossiblyFalseOperand errorLevel="info" />
-        <PossiblyFalsePropertyAssignmentValue errorLevel="info" />
-        <PossiblyFalseReference errorLevel="info" />
-        <PossiblyInvalidArgument errorLevel="info" />
-        <PossiblyInvalidArrayAccess errorLevel="info" />
-        <PossiblyInvalidArrayAssignment errorLevel="info" />
-        <PossiblyInvalidArrayOffset errorLevel="info" />
-        <PossiblyInvalidCast errorLevel="info" />
-        <PossiblyInvalidFunctionCall errorLevel="info" />
-        <PossiblyInvalidIterator errorLevel="info" />
-        <PossiblyInvalidMethodCall errorLevel="info" />
-        <PossiblyInvalidOperand errorLevel="info" />
-        <PossiblyInvalidPropertyAssignment errorLevel="info" />
-        <PossiblyInvalidPropertyAssignmentValue errorLevel="info" />
-        <PossiblyInvalidPropertyFetch errorLevel="info" />
-        <PossiblyNullArgument errorLevel="info" />
-        <PossiblyNullArrayAccess errorLevel="info" />
-        <PossiblyNullArrayAssignment errorLevel="info" />
-        <PossiblyNullArrayOffset errorLevel="info" />
-        <PossiblyNullFunctionCall errorLevel="info" />
-        <PossiblyNullIterator errorLevel="info" />
-        <PossiblyNullOperand errorLevel="info" />
-        <PossiblyNullPropertyAssignment errorLevel="info" />
-        <PossiblyNullPropertyAssignmentValue errorLevel="info" />
-        <PossiblyNullPropertyFetch errorLevel="info" />
-        <PossiblyNullReference errorLevel="info" />
-        <PossiblyUndefinedGlobalVariable errorLevel="info" />
-        <PossiblyUndefinedVariable errorLevel="info" />
-        <PossiblyUndefinedArrayOffset errorLevel="info" />
-        <PossiblyUndefinedMethod errorLevel="info" />
-
-        <!-- level 5 issues - should be avoided at mosts costs... -->
-
-        <ForbiddenCode errorLevel="error" />
-        <ImplicitToStringCast errorLevel="error" />
-        <InvalidScalarArgument errorLevel="error" />
-        <InvalidToString errorLevel="error" />
-        <InvalidOperand errorLevel="error" />
-        <NoInterfaceProperties errorLevel="error" />
         <TooManyArguments errorLevel="suppress" />
-        <TypeDoesNotContainType errorLevel="error" />
-        <TypeDoesNotContainNull errorLevel="error" />
-        <MissingDocblockType errorLevel="error" />
-        <ImplementedReturnTypeMismatch errorLevel="error" />
-
-        <!-- level 6 issues - really bad things -->
-
-        <InvalidNullableReturnType errorLevel="error" />
-        <NullableReturnStatement errorLevel="error" />
-        <InvalidFalsableReturnType errorLevel="error" />
-        <FalsableReturnStatement errorLevel="error" />
-
-        <MoreSpecificImplementedParamType errorLevel="error" />
-        <LessSpecificImplementedReturnType errorLevel="error" />
-
-        <InvalidReturnStatement errorLevel="error" />
-        <InvalidReturnType errorLevel="error" />
-        <UndefinedThisPropertyAssignment errorLevel="error" />
-        <UndefinedInterfaceMethod errorLevel="error" />
-
-        <!-- level 7 issues - even worse -->
-
-        <UndefinedThisPropertyAssignment errorLevel="error" />
-        <UndefinedPropertyAssignment errorLevel="error" />
-        <UndefinedThisPropertyFetch errorLevel="error" />
-        <UndefinedPropertyFetch errorLevel="error" />
-
-        <InvalidReturnStatement errorLevel="error" />
-        <InvalidReturnType errorLevel="error" />
-        <InvalidArgument errorLevel="error" />
-        <InvalidPropertyAssignmentValue errorLevel="error" />
-        <InvalidArrayOffset errorLevel="error" />
-        <InvalidArrayAssignment errorLevel="error" />
-        <InvalidArrayAccess errorLevel="error" />
-        <InvalidClone errorLevel="error" />
-
-        <InvalidGlobal errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
     * Objects: \Clarkson_Core\Object\$template, \Clarkson_Core\Object\$post_type, \Clarkson_Core\Object\base_object, \Clarkson_Core\Object\Clarkson_Object
     * Terms: \Clarkson_Core\Object\$taxonomy, \Clarkson_Core\Object\base_term, \Clarkson_Core\Object\Clarkson_Term
     * Users: \Clarkson_Core\Object\user, \Clarkson_Core\Object\Clarkson_User
+* Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,10 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Extends parameters available in `Clarkson_Core_Gutenberg_Block_Type::clarkson_render_callback`
 * `Clarkson_Object` has a new `get_object()` method.
 * Adds new `clarkson_core_template_context` filter.
+* There is now an object hierarchy:
+    * Objects: \Clarkson_Core\Object\$template, \Clarkson_Core\Object\$post_type, \Clarkson_Core\Object\base_object, \Clarkson_Core\Object\Clarkson_Object
+    * Terms: \Clarkson_Core\Object\$taxonomy, \Clarkson_Core\Object\base_term, \Clarkson_Core\Object\Clarkson_Term
+    * Users: \Clarkson_Core\Object\user, \Clarkson_Core\Object\Clarkson_User
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.
@@ -39,6 +43,7 @@ Backward incompatible changes:
 * Removes `Clarkson_Object::get_json`, which was deprecated in `0.2.0`.
 * The `Clarkson_Term` and `Clarkson_User` interfaces have changed, and you might now get an Exception, instead of an invalid object.
 * Removes deprecated features everywhere except for wordpress-objects/
+* Removes loading of user roles instead of a user object.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,7 @@ Backward incompatible changes:
 * The `Clarkson_Term` and `Clarkson_User` interfaces have changed, and you might now get an Exception, instead of an invalid object.
 * Removes deprecated features everywhere except for wordpress-objects/
 * Removes loading of user roles instead of a user object.
+* Removes deprecated construction of objects by id. Use ::get instead.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,7 @@ Backward incompatible changes:
 * Removes deprecated features everywhere except for wordpress-objects/
 * Removes loading of user roles instead of a user object.
 * Removes deprecated construction of objects by id. Use ::get instead.
+* Objects, term and user creation calls (such as ::get and ::get_one) now return null instead of throwing an error when no valid result is found.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
     * Terms: \Clarkson_Core\Object\$taxonomy, \Clarkson_Core\Object\base_term, \Clarkson_Core\Object\Clarkson_Term
     * Users: \Clarkson_Core\Object\user, \Clarkson_Core\Object\Clarkson_User
 * Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
+* Adds `clarkson_term_types` and `clarkson_user_type` filters to overwrite class lookup.
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -77,7 +77,7 @@ class Autoloader {
 	 *
 	 * @return string Sanitized object name.
 	 */
-	public function sanitize_object_name( $str ) {
+	public function sanitize_object_name( $str ):string {
 
 		$str = trim( $str );
 
@@ -101,7 +101,7 @@ class Autoloader {
 	 * @param string $post_type Post type.
 	 * @internal
 	 */
-	public function registered_post_type( $post_type ) {
+	public function registered_post_type( $post_type ):void {
 		$this->post_types[ $this->sanitize_object_name( $post_type ) ] = $this->sanitize_object_name( $post_type );
 	}
 
@@ -111,7 +111,7 @@ class Autoloader {
 	 * @param string $taxonomy Taxonomy name.
 	 * @internal
 	 */
-	public function registered_taxonomy( $taxonomy ) {
+	public function registered_taxonomy( $taxonomy ):void {
 		$this->taxonomies[ $this->sanitize_object_name( $taxonomy ) ] = $this->sanitize_object_name( $taxonomy );
 	}
 
@@ -125,13 +125,13 @@ class Autoloader {
 	 *
 	 * @return string
 	 */
-	public function get_template_filename( $post_id ) {
+	public function get_template_filename( $post_id ):string {
 		$page_template_slug = get_page_template_slug( $post_id );
 		$filename           = '';
 
 		if ( ! empty( $page_template_slug ) ) {
 			$pathinfo = pathinfo( $page_template_slug );
-			$filename = array_key_exists( 'filename', $pathinfo ) ? $pathinfo['filename'] : '';
+			$filename = array_key_exists( 'filename', $pathinfo ) ? (string) $pathinfo['filename'] : '';
 		}
 		return $filename;
 	}
@@ -140,7 +140,7 @@ class Autoloader {
 	 * Fill $extra variable with the current custom template
 	 * @internal
 	 */
-	public function load_template_objects() {
+	public function load_template_objects():void {
 		$template_name = $this->get_template_filename( get_queried_object_id() );
 
 		if ( $template_name && ! empty( $template_name ) ) {
@@ -176,7 +176,7 @@ class Autoloader {
 	 * Register user types.
 	 * @internal
 	 */
-	public function register_user_types() {
+	public function register_user_types():void {
 		global $wp_roles;
 
 		// Default is 'user'.
@@ -196,7 +196,7 @@ class Autoloader {
 	 * @param string $classname Class name.
 	 * @internal
 	 */
-	protected function load_wordpress_objects( $classname ) {
+	protected function load_wordpress_objects( $classname ):void {
 		$type = $this->sanitize_object_name( $classname );
 
 		// This is faster than a class_exists check.

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -5,12 +5,14 @@
  * @package CLARKSON\Lib
  */
 
+namespace Clarkson_Core;
+
 /**
- * Clarkson_Core_Autoloader class.
+ * Autoloader class.
  * Registers post types and taxonomies, users and WP Objects.
  * @internal
  */
-class Clarkson_Core_Autoloader {
+class Autoloader {
 	/**
 	 * Define Post types.
 	 *

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -14,57 +14,12 @@ namespace Clarkson_Core;
  */
 class Autoloader {
 	/**
-	 * Define Post types.
-	 *
-	 * @var array $post_types Post types.
-	 * @internal
-	 */
-	public $post_types = array();
-
-	/**
-	 * Define Taxonomies.
-	 *
-	 * @var array $taxonomies Taxonomies.
-	 * @internal
-	 */
-	public $taxonomies = array();
-
-	/**
-	 * Define User types.
-	 *
-	 * @var array $user_types User types.
-	 * @internal
-	 */
-	public $user_types = array();
-
-	/**
 	 * Define the prefix for the custom user Object classes.
 	 *
 	 * @var string $user_objectname_prefix Classname prefix.
 	 * @internal
 	 */
 	public $user_objectname_prefix = 'user_';
-
-
-	/**
-	 * Define Extra.
-	 *
-	 * @var array $extra Extra.
-	 * @internal
-	 */
-	public $extra = array();
-
-
-	/**
-	 * Clarkson_Core_Autoloader constructor.
-	 */
-	public function __construct() {
-		add_action( 'registered_post_type', array( $this, 'registered_post_type' ), 10, 1 );
-		add_action( 'registered_taxonomy', array( $this, 'registered_taxonomy' ), 10, 1 );
-		add_action( 'init', array( $this, 'register_user_types' ), 10, 1 );
-		add_action( 'wp', array( $this, 'load_template_objects' ) );
-		spl_autoload_register( array( $this, 'load_wordpress_objects' ), true, true );
-	}
 
 	/**
 	 * Changes object names into valid classnames.
@@ -78,7 +33,6 @@ class Autoloader {
 	 * @return string Sanitized object name.
 	 */
 	public function sanitize_object_name( $str ):string {
-
 		$str = trim( $str );
 
 		// Replace - with _ .
@@ -92,29 +46,6 @@ class Autoloader {
 
 		return $str;
 	}
-
-	/**
-	 * Fill $post_type variable with all registered CPT's, every time a post type is registered via WordPress after the "registered_post_type" action.
-	 *
-	 * This also means reserved ones like page, post, attachment, revision, nav_menu_item, custom_css and customize_changeset.
-	 *
-	 * @param string $post_type Post type.
-	 * @internal
-	 */
-	public function registered_post_type( $post_type ):void {
-		$this->post_types[ $this->sanitize_object_name( $post_type ) ] = $this->sanitize_object_name( $post_type );
-	}
-
-	/**
-	 * Fill $taxonomies variable with all registered Taxonomies, every time a taxonomy is registered via WordPress after the "registered_taxonomy" action.
-	 *
-	 * @param string $taxonomy Taxonomy name.
-	 * @internal
-	 */
-	public function registered_taxonomy( $taxonomy ):void {
-		$this->taxonomies[ $this->sanitize_object_name( $taxonomy ) ] = $this->sanitize_object_name( $taxonomy );
-	}
-
 
 	/**
 	 * Returns the page template filename without extension.
@@ -134,90 +65,5 @@ class Autoloader {
 			$filename = array_key_exists( 'filename', $pathinfo ) ? (string) $pathinfo['filename'] : '';
 		}
 		return $filename;
-	}
-
-	/**
-	 * Fill $extra variable with the current custom template
-	 * @internal
-	 */
-	public function load_template_objects():void {
-		$template_name = $this->get_template_filename( get_queried_object_id() );
-
-		if ( $template_name && ! empty( $template_name ) ) {
-			$template_name                 = $this->sanitize_object_name( $template_name );
-			$this->extra[ $template_name ] = $template_name;
-		}
-
-		/**
-		 * Adds available templates to the known available templates list.
-		 *
-		 * @hook clarkson_core_available_templates
-		 * @since 0.4.1
-		 * @param {string[]} $this->extra Templates automatically found by Clarkson Core.
-		 * @return {string[]} Templates that should be available as objects to Clarkson_Core_Objects.
-		 * @see https://github.com/level-level/Clarkson-Core/issues/161
-		 *
-		 * @example
-		 * // Use custom templates in the theme.
-		 * add_filter(
-		 *  'clarkson_core_available_templates',
-		 *  function() {
-		 *      return array(
-		 *          'template_landingpage',
-		 *          'template_frontpage',
-		 *      );
-		 *  }
-		 * );
-		 */
-		$this->extra = apply_filters( 'clarkson_core_available_templates', $this->extra );
-	}
-
-	/**
-	 * Register user types.
-	 * @internal
-	 */
-	public function register_user_types():void {
-		global $wp_roles;
-
-		// Default is 'user'.
-		$this->user_types[ $this->sanitize_object_name( 'user' ) ] = $this->sanitize_object_name( 'user' );
-
-		// Now register user role based classes.
-		// We prefix every role with user_ so we within the wordpress-objects directory all types will be grouped together
-		foreach ( $wp_roles->roles as $key => $role ) {
-			$class_name                      = $this->sanitize_object_name( $this->user_objectname_prefix . $key );
-			$this->user_types[ $class_name ] = $class_name;
-		}
-	}
-
-	/**
-	 * Load all files of each WordPress object.
-	 *
-	 * @param string $classname Class name.
-	 * @internal
-	 */
-	protected function load_wordpress_objects( $classname ):void {
-		$type = $this->sanitize_object_name( $classname );
-
-		// This is faster than a class_exists check.
-		if ( ! in_array( $type, $this->post_types, true ) && ! in_array( $type, $this->taxonomies, true ) && ! in_array( $type, $this->extra, true ) && ! in_array( $type, $this->user_types, true ) ) {
-			return;
-		}
-
-		$filename = "{$classname}.php";
-
-		// Load child theme first.
-		$filepath = realpath( get_stylesheet_directory() ) . "/wordpress-objects/{$filename}";
-		if ( file_exists( $filepath ) ) {
-			include_once $filepath;
-			return;
-		}
-
-		// If not exists then load normal / parent theme.
-		$filepath = realpath( get_template_directory() ) . "/wordpress-objects/{$filename}";
-		if ( file_exists( $filepath ) ) {
-			include_once $filepath;
-			return;
-		}
 	}
 }

--- a/src/Gutenberg/Block_Manager.php
+++ b/src/Gutenberg/Block_Manager.php
@@ -8,6 +8,8 @@
 
 namespace Clarkson_Core\Gutenberg;
 
+use WP_Block_Type;
+
 /**
  * Intercepts 'the content' filter to allow overriding of the rendering functions
  * of Gutenberg blocks. This allows us to use twig for block rendering.
@@ -17,7 +19,7 @@ class Block_Manager {
 	 * Hook in as soon as we can, to replace blocks with the Clarkson-block equivalent.
 	 * @internal
 	 */
-	public function init() {
+	public function init():void {
 		if ( class_exists( '\WP_Block_Type_Registry' ) ) {
 			add_filter( 'the_content', array( $this, 'intercept_gutenberg_rendering' ), 1 );
 		}
@@ -96,7 +98,7 @@ class Block_Manager {
 	 *
 	 * Does not manipulate the $content.
 	 *
-	 * @param $content string The content string to be ouputted. Not manipulated
+	 * @param string $content  The content string to be ouputted. Not manipulated
 	 * at this stage.
 	 * @return string
 	 *
@@ -107,8 +109,10 @@ class Block_Manager {
 		foreach ( $block_registry->get_all_registered() as $original_block ) {
 			$block_type     = $this->determine_block_type_class( $original_block );
 			$clarkson_block = new $block_type( $original_block->name, get_object_vars( $original_block ) );
-			$block_registry->unregister( $original_block );
-			$block_registry->register( $clarkson_block );
+			if($clarkson_block instanceof WP_Block_Type){
+				$block_registry->unregister( $original_block );
+				$block_registry->register( $clarkson_block );
+			}
 		}
 		return $content;
 	}

--- a/src/Gutenberg/Block_Manager.php
+++ b/src/Gutenberg/Block_Manager.php
@@ -6,11 +6,13 @@
  * @since 0.4.0
  */
 
+namespace Clarkson_Core\Gutenberg;
+
 /**
  * Intercepts 'the content' filter to allow overriding of the rendering functions
  * of Gutenberg blocks. This allows us to use twig for block rendering.
  */
-class Clarkson_Core_Gutenberg_Block_Manager {
+class Block_Manager {
 	/**
 	 * Hook in as soon as we can, to replace blocks with the Clarkson-block equivalent.
 	 * @internal

--- a/src/Gutenberg/Block_Manager.php
+++ b/src/Gutenberg/Block_Manager.php
@@ -109,7 +109,7 @@ class Block_Manager {
 		foreach ( $block_registry->get_all_registered() as $original_block ) {
 			$block_type     = $this->determine_block_type_class( $original_block );
 			$clarkson_block = new $block_type( $original_block->name, get_object_vars( $original_block ) );
-			if($clarkson_block instanceof WP_Block_Type){
+			if ( $clarkson_block instanceof WP_Block_Type ) {
 				$block_registry->unregister( $original_block );
 				$block_registry->register( $clarkson_block );
 			}

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -6,11 +6,15 @@
  * @since 0.4.0
  */
 
+namespace Clarkson_Core\Gutenberg;
+
+use Clarkson_Core\Templates;
+
 /**
  * This custom block overwrites the render callback to use twig files.
  * It is automatically injected into all registered blocks at render time.
  */
-class Clarkson_Core_Gutenberg_Block_Type extends \WP_Block_Type {
+class Block_Type extends \WP_Block_Type {
 	/**
 	 * Replaces the original block render function, and saves the original render
 	 * function in case we can't find a fitting twig file.
@@ -78,7 +82,7 @@ class Clarkson_Core_Gutenberg_Block_Type extends \WP_Block_Type {
 	 */
 	public function clarkson_render_callback( $attributes, $content ) {
 		if ( file_exists( $this->get_twig_template_path() ) ) {
-			$cc_template              = Clarkson_Core_Templates::get_instance();
+			$cc_template              = Templates::get_instance();
 			$this->content_attributes = $attributes;
 			return (string) $cc_template->render_twig(
 				$this->get_twig_template_path(),

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -370,17 +370,11 @@ class Clarkson_Object implements \JsonSerializable {
 
 	/**
 	 * Get the post author object.
-	 *
-	 * @return null|Clarkson_User
 	 */
-	public function get_author() {
+	public function get_author(): ?Clarkson_User {
 
 		if ( $this->_post->post_author ) {
-			try {
-				return Clarkson_User::get( (int) $this->_post->post_author );
-			} catch ( \Exception $e ) {
-				return null;
-			}
+			return Clarkson_User::get( (int) $this->_post->post_author );
 		}
 
 		return null;

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -5,6 +5,10 @@
  * @package CLARKSON\Objects
  */
 
+namespace Clarkson_Core\Object;
+
+use Clarkson_Core\Objects;
+
 /**
  * Object oriented implementation of WordPress post objects.
  */
@@ -20,7 +24,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Define $_post.
 	 *
-	 * @var WP_Post
+	 * @var \WP_Post
 	 */
 	protected $_post;
 
@@ -48,9 +52,9 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Clarkson_Object constructor.
 	 *
-	 * @param WP_Post $post Post object.
+	 * @param \WP_Post $post Post object.
 	 *
-	 * @throws Exception    Error message.
+	 * @throws \Exception    Error message.
 	 */
 	public function __construct( $post ) {
 		if ( is_a( $post, 'WP_Post' ) ) {
@@ -59,12 +63,12 @@ class Clarkson_Object implements \JsonSerializable {
 			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Use \'::get(post)\' instead.', '0.2.0' );
 
 			if ( empty( $post ) ) {
-				throw new Exception( '$post empty' );
+				throw new \Exception( '$post empty' );
 			}
 
 			$post_object = get_post( $post );
-			if ( ! $post_object instanceof WP_Post ) {
-				throw new Exception( '$post empty' );
+			if ( ! $post_object instanceof \WP_Post ) {
+				throw new \Exception( '$post empty' );
 			}
 
 			$this->_post = $post_object;
@@ -77,20 +81,20 @@ class Clarkson_Object implements \JsonSerializable {
 	 *
 	 * @param string $name Post name to check.
 	 *
-	 * @throws Exception Error message.
+	 * @throws \Exception Error message.
 	 */
 	public function __get( $name ) {
 		if ( in_array( $name, array( 'post_name', 'post_title', 'ID', 'post_author', 'post_type', 'post_status' ), true ) ) {
-			throw new Exception( 'Trying to access wp_post object properties from Post object' );
+			throw new \Exception( 'Trying to access wp_post object properties from Post object' );
 		}
 	}
 
 	/**
 	 * Get the WordPress post object.
 	 *
-	 * @return null|WP_Post The post object.
+	 * @return null|\WP_Post The post object.
 	 */
-	public function get_object(): ?WP_Post {
+	public function get_object(): ?\WP_Post {
 		return $this->_post;
 	}
 
@@ -107,7 +111,7 @@ class Clarkson_Object implements \JsonSerializable {
 
 			try {
 				static::$posts[ $id ] = new $class( get_post( $id ) );
-			} catch ( Exception $e ) {
+			} catch ( \Exception $e ) {
 				static::$posts[ $id ] = null;
 			}
 		}
@@ -180,7 +184,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Get the parent of the post, if any.
 	 *
-	 * @return \Clarkson_Object|null
+	 * @return Clarkson_Object|null
 	 */
 	public function get_parent() {
 		if ( $this->_post->post_parent ) {
@@ -419,7 +423,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Get the post author object.
 	 *
-	 * @return null|\Clarkson_User
+	 * @return null|Clarkson_User
 	 */
 	public function get_author() {
 
@@ -518,11 +522,11 @@ class Clarkson_Object implements \JsonSerializable {
 	 *
 	 * @return false|int
 	 *
-	 * @throws Exception Error message.
+	 * @throws \Exception Error message.
 	 */
 	public function add_comment( $comment_text, $user_id ) {
 		if ( empty( $comment_text ) || empty( $user_id ) ) {
-			throw new Exception( 'Not enough data' );
+			throw new \Exception( 'Not enough data' );
 		}
 
 		$comment = array(
@@ -534,7 +538,7 @@ class Clarkson_Object implements \JsonSerializable {
 		$result = wp_insert_comment( $comment );
 
 		if ( ! is_numeric( $result ) ) {
-			throw new Exception( 'wp_insert_comment failed: ' . $comment_text );
+			throw new \Exception( 'wp_insert_comment failed: ' . $comment_text );
 		}
 
 		return $result;
@@ -546,7 +550,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 * @param string $taxonomy Optional. The taxonomy for which to retrieve terms. Default 'post_tag'.
 	 * @param array  $args     Optional. {@link wp_get_object_terms()} arguments. Default empty array.
 	 *
-	 * @return \Clarkson_Term[]|WP_Error List of post tags or a WP_Error.
+	 * @return Clarkson_Term[]|\WP_Error List of post tags or a WP_Error.
 	 */
 	public function get_terms( $taxonomy, $args = array() ) {
 		$terms = wp_get_post_terms( $this->get_id(), $taxonomy, $args );
@@ -558,7 +562,7 @@ class Clarkson_Object implements \JsonSerializable {
 
 		return array_map(
 			function( $term ) {
-				return \Clarkson_Core_Objects::get_instance()->get_term( $term );
+				return Objects::get_instance()->get_term( $term );
 			},
 			$terms
 		);
@@ -567,9 +571,9 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Add a single term to a post.
 	 *
-	 * @param \Clarkson_Term $term    Term data.
+	 * @param Clarkson_Term $term    Term data.
 	 *
-	 * @return array|WP_Error Affected Term IDs.
+	 * @return array|\WP_Error Affected Term IDs.
 	 */
 	public function add_term( $term ) {
 		return wp_set_object_terms( $this->get_id(), $term->get_id(), $term->get_taxonomy(), true );
@@ -579,10 +583,10 @@ class Clarkson_Object implements \JsonSerializable {
 	 * Bulk add terms to a post.
 	 *
 	 * @param string           $taxonomy Taxonomy.
-	 * @param \Clarkson_Term[] $terms    Terms.
-	 * @var   \Clarkson_Term   $term     Term objects.
+	 * @param Clarkson_Term[] $terms    Terms.
+	 * @var   Clarkson_Term   $term     Term objects.
 	 *
-	 * @return array|WP_Error            Terms array.
+	 * @return array|\WP_Error            Terms array.
 	 */
 	public function add_terms( $taxonomy, $terms ) {
 		// Filter terms to ensure they are in the correct taxonomy.
@@ -610,10 +614,10 @@ class Clarkson_Object implements \JsonSerializable {
 	 * Adds all passed terms or overwrites existing terms.
 	 *
 	 * @param string           $taxonomy Taxonomy.
-	 * @param \Clarkson_Term[] $terms    Terms.
-	 * @var   \Clarkson_Term   $term     Term objects.
+	 * @param Clarkson_Term[] $terms    Terms.
+	 * @var   Clarkson_Term   $term     Term objects.
 	 *
-	 * @return array|WP_Error             Affected Term IDs.
+	 * @return array|\WP_Error             Affected Term IDs.
 	 */
 	public function reset_terms( $taxonomy, $terms ) {
 		// Filter terms to ensure they are in the correct taxonomy.
@@ -638,9 +642,9 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Remove a post term.
 	 *
-	 * @param  \Clarkson_Term $term Post term.
+	 * @param  Clarkson_Term $term Post term.
 	 *
-	 * @return bool|WP_Error        True on success, false or WP_Error on failure.
+	 * @return bool|\WP_Error        True on success, false or WP_Error on failure.
 	 */
 	public function remove_term( $term ) {
 		return wp_remove_object_terms( $this->get_id(), $term->get_id(), $term->get_taxonomy() );
@@ -649,7 +653,7 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Is post associated with term?
 	 *
-	 * @param  \Clarkson_Term $term Post term.
+	 * @param  Clarkson_Term $term Post term.
 	 * @return boolean
 	 */
 	public function has_term( $term ) {

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -632,7 +632,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 * We can't just return $this->_post, because these values will only return raw unfiltered data.
 	 */
 	public function jsonSerialize() {
-		$data = array();
+		$data              = array();
 		$data['id']        = $this->get_id();
 		$data['link']      = $this->get_permalink();
 		$data['slug']      = $this->get_post_name();
@@ -647,7 +647,7 @@ class Clarkson_Object implements \JsonSerializable {
 		$data['author'] = null;
 
 		$author_id = $this->get_author_id();
-		$author = $this->get_author();
+		$author    = $this->get_author();
 		if ( ! empty( $author_id ) && $author ) {
 			$data['author'] = array(
 				'id'           => $author_id,

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -486,7 +486,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 * @param string $comment_text Comment text.
 	 * @param int    $user_id      User id.
 	 *
-	 * @return false|int
+	 * @return int
 	 *
 	 * @throws \Exception Error message.
 	 */
@@ -503,7 +503,7 @@ class Clarkson_Object implements \JsonSerializable {
 
 		$result = wp_insert_comment( $comment );
 
-		if ( ! is_numeric( $result ) ) {
+		if ( false === $result ) {
 			throw new \Exception( 'wp_insert_comment failed: ' . $comment_text );
 		}
 

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -615,11 +615,10 @@ class Clarkson_Object implements \JsonSerializable {
 
 		$data['author'] = null;
 
-		$author_id = $this->get_author_id();
-		$author    = $this->get_author();
-		if ( ! empty( $author_id ) && $author ) {
+		$author = $this->get_author();
+		if ( $author instanceof Clarkson_User ) {
 			$data['author'] = array(
-				'id'           => $author_id,
+				'id'           => $author->get_id(),
 				'display_name' => $author->get_display_name(),
 			);
 		}

--- a/src/Object/Clarkson_Term.php
+++ b/src/Object/Clarkson_Term.php
@@ -32,14 +32,12 @@ class Clarkson_Term {
 	 *
 	 * @param string      $name     Term name.
 	 * @param null|string $taxonomy Taxonomy.
-	 *
-	 * @return Clarkson_Term Term object.
 	 */
-	public static function get_by_name( $name, $taxonomy = null ) {
+	public static function get_by_name( $name, $taxonomy = null ): ?Clarkson_Term {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'name', $name, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new \Exception( "Term not found ($taxonomy:$name)" );
+			return null;
 		}
 		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
@@ -52,11 +50,11 @@ class Clarkson_Term {
 	 *
 	 * @return Clarkson_Term          Term object.
 	 */
-	public static function get_by_slug( $slug, $taxonomy = null ) {
+	public static function get_by_slug( $slug, $taxonomy = null ): ?Clarkson_Term {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'slug', $slug, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new \Exception( "Term not found ($taxonomy:$slug)" );
+			return null;
 		}
 		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
@@ -66,22 +64,18 @@ class Clarkson_Term {
 	 *
 	 * @param int         $term_id  Term id.
 	 * @param null|string $taxonomy Taxonomy.
-	 *
-	 * @return Clarkson_Term          Term object.
 	 */
-	public static function get_by_id( $term_id, $taxonomy = null ) {
+	public static function get_by_id( $term_id, $taxonomy = null ): ?Clarkson_Term {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'id', $term_id, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new \Exception( "Term not found ($taxonomy:$term_id)" );
+			return null;
 		}
 		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
 
 	/**
 	 * Clarkson_Term constructor.
-	 *
-	 * @throws \Exception  Error message.
 	 */
 	public function __construct( \WP_Term $term ) {
 		$this->_term = $term;
@@ -131,10 +125,8 @@ class Clarkson_Term {
 
 	/**
 	 * Get the term parent.
-	 *
-	 * @return null|static Term parent object.
 	 */
-	public function get_parent() {
+	public function get_parent(): ?Clarkson_Term {
 		$parent = null;
 		if ( $this->_term->parent ) {
 			try {

--- a/src/Object/Clarkson_Term.php
+++ b/src/Object/Clarkson_Term.php
@@ -23,9 +23,9 @@ class Clarkson_Term {
 	/**
 	 * Clarkson_Term provides extra functions to retrieve term and taxonomy data.
 	 *
-	 * @var null
+	 * @var string
 	 */
-	protected static $taxonomy = null;
+	protected static $taxonomy = '';
 
 	/**
 	 * Get term by name.
@@ -251,7 +251,7 @@ class Clarkson_Term {
 	 *
 	 * @param string $name New term name.
 	 */
-	public function set_name( $name ) {
+	public function set_name( $name ):void {
 		wp_update_term(
 			$this->get_id(),
 			$this->get_taxonomy(),

--- a/src/Object/Clarkson_Term.php
+++ b/src/Object/Clarkson_Term.php
@@ -5,6 +5,8 @@
  * @package CLARKSON\Objects
  */
 
+namespace Clarkson_Core\Object;
+
 /**
  * Object oriented wrapper for WP_Term objects.
  */
@@ -31,15 +33,15 @@ class Clarkson_Term {
 	 * @param string      $name     Term name.
 	 * @param null|string $taxonomy Taxonomy.
 	 *
-	 * @return \Clarkson_Term Term object.
+	 * @return Clarkson_Term Term object.
 	 */
 	public static function get_by_name( $name, $taxonomy = null ) {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'name', $name, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new Exception( "Term not found ($taxonomy:$name)" );
+			throw new \Exception( "Term not found ($taxonomy:$name)" );
 		}
-		return \Clarkson_Core_Objects::get_instance()->get_term( $term );
+		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
 
 	/**
@@ -48,15 +50,15 @@ class Clarkson_Term {
 	 * @param string      $slug     Term slug.
 	 * @param null|string $taxonomy Taxonomy.
 	 *
-	 * @return \Clarkson_Term          Term object.
+	 * @return Clarkson_Term          Term object.
 	 */
 	public static function get_by_slug( $slug, $taxonomy = null ) {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'slug', $slug, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new Exception( "Term not found ($taxonomy:$slug)" );
+			throw new \Exception( "Term not found ($taxonomy:$slug)" );
 		}
-		return \Clarkson_Core_Objects::get_instance()->get_term( $term );
+		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
 
 	/**
@@ -65,15 +67,15 @@ class Clarkson_Term {
 	 * @param int         $term_id  Term id.
 	 * @param null|string $taxonomy Taxonomy.
 	 *
-	 * @return \Clarkson_Term          Term object.
+	 * @return Clarkson_Term          Term object.
 	 */
 	public static function get_by_id( $term_id, $taxonomy = null ) {
 		$taxonomy = $taxonomy ?: static::$taxonomy;
 		$term     = get_term_by( 'id', $term_id, $taxonomy );
 		if ( ! $term instanceof \WP_Term ) {
-			throw new Exception( "Term not found ($taxonomy:$term_id)" );
+			throw new \Exception( "Term not found ($taxonomy:$term_id)" );
 		}
-		return \Clarkson_Core_Objects::get_instance()->get_term( $term );
+		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
 	}
 
 	/**
@@ -82,7 +84,7 @@ class Clarkson_Term {
 	 * @param \WP_Term|int $term  \WPTerm object or (deprecated) term id.
 	 * @param null|string  $taxonomy Taxonomy.
 	 *
-	 * @throws Exception  Error message.
+	 * @throws \Exception  Error message.
 	 */
 	public function __construct( $term, $taxonomy = null ) {
 		if ( $term instanceof \WP_Term ) {
@@ -91,11 +93,11 @@ class Clarkson_Term {
 			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Use \'::get_by_id(term_id)\' instead.', '0.2.0' );
 			$taxonomy = $taxonomy ?: static::$taxonomy;
 			if ( empty( $term ) || ! $taxonomy ) {
-				throw new Exception( $term . ' or ' . $taxonomy . ' empty' );
+				throw new \Exception( $term . ' or ' . $taxonomy . ' empty' );
 			}
 			$term_result = get_term( (int) $term, $taxonomy );
-			if ( ! $term_result instanceof WP_Term ) {
-				throw new Exception( "Term not found ($taxonomy:$term)" );
+			if ( ! $term_result instanceof \WP_Term ) {
+				throw new \Exception( "Term not found ($taxonomy:$term)" );
 			}
 			$this->_term = $term_result;
 		}
@@ -106,11 +108,11 @@ class Clarkson_Term {
 	 *
 	 * @param string $name Field to search by.
 	 *
-	 * @throws Exception       Error message.
+	 * @throws \Exception       Error message.
 	 */
 	public function __get( $name ) {
 		if ( in_array( $name, array( 'term_id', 'name', 'slug', 'taxonomy' ), true ) ) {
-			throw new Exception( 'Trying to access wp_term object properties from Term object' );
+			throw new \Exception( 'Trying to access wp_term object properties from Term object' );
 		}
 	}
 
@@ -187,7 +189,7 @@ class Clarkson_Term {
 	 * @param string $key   Meta key.
 	 * @param mixed  $value New meta data.
 	 *
-	 * @return int|WP_Error|bool
+	 * @return int|\WP_Error|bool
 	 */
 	public function update_meta( $key, $value ) {
 		return update_term_meta( $this->get_id(), $key, $value );
@@ -199,7 +201,7 @@ class Clarkson_Term {
 	 * @param string $key   Meta key.
 	 * @param mixed  $value New meta data.
 	 *
-	 * @return bool|int|WP_Error
+	 * @return bool|int|\WP_Error
 	 */
 	public function add_meta( $key, $value ) {
 		return add_term_meta( $this->get_id(), $key, $value );
@@ -280,7 +282,7 @@ class Clarkson_Term {
 	/**
 	 * Get the term permalink.
 	 *
-	 * @return string|WP_Error Term permalink.
+	 * @return string|\WP_Error Term permalink.
 	 */
 	public function get_permalink() {
 		return get_term_link( $this->get_term(), $this->get_taxonomy() );

--- a/src/Object/Clarkson_Term.php
+++ b/src/Object/Clarkson_Term.php
@@ -81,26 +81,10 @@ class Clarkson_Term {
 	/**
 	 * Clarkson_Term constructor.
 	 *
-	 * @param \WP_Term|int $term  \WPTerm object or (deprecated) term id.
-	 * @param null|string  $taxonomy Taxonomy.
-	 *
 	 * @throws \Exception  Error message.
 	 */
-	public function __construct( $term, $taxonomy = null ) {
-		if ( $term instanceof \WP_Term ) {
-			$this->_term = $term;
-		} else {
-			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Use \'::get_by_id(term_id)\' instead.', '0.2.0' );
-			$taxonomy = $taxonomy ?: static::$taxonomy;
-			if ( empty( $term ) || ! $taxonomy ) {
-				throw new \Exception( $term . ' or ' . $taxonomy . ' empty' );
-			}
-			$term_result = get_term( (int) $term, $taxonomy );
-			if ( ! $term_result instanceof \WP_Term ) {
-				throw new \Exception( "Term not found ($taxonomy:$term)" );
-			}
-			$this->_term = $term_result;
-		}
+	public function __construct( \WP_Term $term ) {
+		$this->_term = $term;
 	}
 
 	/**

--- a/src/Object/Clarkson_User.php
+++ b/src/Object/Clarkson_User.php
@@ -18,47 +18,25 @@ class Clarkson_User {
 	 */
 	protected $_user;
 
-
-	/**
-	 * Current user.
-	 *
-	 * @var \WP_User $_current_user
-	 */
-	protected static $_current_user;
-
-	/**
-	 * Users.
-	 *
-	 * @var static[] $users
-	 */
-	protected static $users;
-
 	/**
 	 * Get the current logged in user.
-	 *
-	 * @return Clarkson_User User status.
-	 * @throws \Exception  User is not logged in.
 	 */
-	public static function current_user() {
+	public static function current_user(): ?Clarkson_User {
 		if ( is_user_logged_in() ) {
 			return static::get( get_current_user_id() );
-		} else {
-			throw new \Exception( 'User is not logged in' );
 		}
+		return null;
 	}
-
 
 	/**
 	 * Get user data by user id.
 	 *
 	 * @param  int $id User id.
-	 * @return Clarkson_User
-	 * @throws \Exception In case a requested user ID does not exist.
 	 */
-	public static function get( $id ) {
+	public static function get( $id ): ?Clarkson_User {
 		$user = get_userdata( $id );
 		if ( ! $user instanceof \WP_User ) {
-			throw new \Exception( "User not found ($id)" );
+			return null;
 		}
 
 		return Objects::get_instance()->get_user( $user );
@@ -66,8 +44,6 @@ class Clarkson_User {
 
 	/**
 	 * Clarkson_User constructor.
-	 *
-	 * @throws \Exception          User status.
 	 */
 	public function __construct( \WP_User $user ) {
 		$this->_user = $user;
@@ -84,10 +60,8 @@ class Clarkson_User {
 
 	/**
 	 * Get the WordPress WP_User object.
-	 *
-	 * @return \WP_User
 	 */
-	public function get_user() {
+	public function get_user(): \WP_User {
 		return $this->_user;
 	}
 

--- a/src/Object/Clarkson_User.php
+++ b/src/Object/Clarkson_User.php
@@ -67,24 +67,10 @@ class Clarkson_User {
 	/**
 	 * Clarkson_User constructor.
 	 *
-	 * @param  \WP_User|int $user WP_User object (or deprecated User id).
 	 * @throws \Exception          User status.
 	 */
-	public function __construct( $user ) {
-		if ( $user instanceof \WP_User ) {
-			$this->_user = $user;
-		} else {
-			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Supply a \WP_User object or use \'::get(user_id)\' instead.', '1.0.0' );
-			if ( empty( $user ) ) {
-				throw new \Exception( $user . ' empty' );
-			}
-
-			$user_object = get_userdata( $user );
-			if ( ! $user_object instanceof \WP_User ) {
-				throw new \Exception( $user . ' does not exist' );
-			}
-			$this->_user = $user_object;
-		}
+	public function __construct( \WP_User $user ) {
+		$this->_user = $user;
 	}
 
 	/**

--- a/src/Object/Clarkson_User.php
+++ b/src/Object/Clarkson_User.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * Clarkson User.
- *
- * @package CLARKSON\Objects
  */
+
+namespace Clarkson_Core\Object;
+
+use Clarkson_Core\Objects;
 
 /**
  * Object oriented wrapper for WP_User objects.
@@ -34,14 +36,14 @@ class Clarkson_User {
 	/**
 	 * Get the current logged in user.
 	 *
-	 * @return \Clarkson_User User status.
-	 * @throws Exception  User is not logged in.
+	 * @return Clarkson_User User status.
+	 * @throws \Exception  User is not logged in.
 	 */
 	public static function current_user() {
 		if ( is_user_logged_in() ) {
 			return static::get( get_current_user_id() );
 		} else {
-			throw new Exception( 'User is not logged in' );
+			throw new \Exception( 'User is not logged in' );
 		}
 	}
 
@@ -50,23 +52,23 @@ class Clarkson_User {
 	 * Get user data by user id.
 	 *
 	 * @param  int $id User id.
-	 * @return \Clarkson_User
+	 * @return Clarkson_User
 	 * @throws \Exception In case a requested user ID does not exist.
 	 */
 	public static function get( $id ) {
 		$user = get_userdata( $id );
 		if ( ! $user instanceof \WP_User ) {
-			throw new Exception( "User not found ($id)" );
+			throw new \Exception( "User not found ($id)" );
 		}
 
-		return \Clarkson_Core_Objects::get_instance()->get_user( $user );
+		return Objects::get_instance()->get_user( $user );
 	}
 
 	/**
 	 * Clarkson_User constructor.
 	 *
 	 * @param  \WP_User|int $user WP_User object (or deprecated User id).
-	 * @throws Exception          User status.
+	 * @throws \Exception          User status.
 	 */
 	public function __construct( $user ) {
 		if ( $user instanceof \WP_User ) {
@@ -74,12 +76,12 @@ class Clarkson_User {
 		} else {
 			_doing_it_wrong( __METHOD__, 'Deprecated __construct called with an ID. Supply a \WP_User object or use \'::get(user_id)\' instead.', '1.0.0' );
 			if ( empty( $user ) ) {
-				throw new Exception( $user . ' empty' );
+				throw new \Exception( $user . ' empty' );
 			}
 
 			$user_object = get_userdata( $user );
 			if ( ! $user_object instanceof \WP_User ) {
-				throw new Exception( $user . ' does not exist' );
+				throw new \Exception( $user . ' does not exist' );
 			}
 			$this->_user = $user_object;
 		}

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -49,6 +49,26 @@ class Objects {
 			self::OBJECT_CLASS_NAMESPACE . 'base_term',
 		);
 
+		/**
+		 * Allows the theme to overwrite classes to look for when creating an object.
+		 *
+		 * @hook clarkson_term_types
+		 * @since 1.0.0
+		 * @param {array} $typse Sanitized class names to load.
+		 * @param {\WP_Term} $term Term which we are trying to convert into an object.
+		 * @return {array} Class names to search for.
+		 *
+		 * @example
+		 * // load a different class instead of what Clarkson Core calculates.
+		 * add_filter( 'clarkson_term_types', function( $types, $term ) {
+		 *  if ( $term->taxonomy === 'gm_category' ){
+		 *      array_unshift($types, self::OBJECT_CLASS_NAMESPACE . 'custom_taxonomy_class';
+		 *  }
+		 *  return $types;
+		 * }, 10, 2 );
+		 */
+		$types = apply_filters( 'clarkson_term_types', $types, $term );
+
 		foreach ( $types as $type ) {
 			if ( class_exists( $type ) ) {
 				$term_object = new $type( $term );
@@ -90,6 +110,26 @@ class Objects {
 		 * @psalm-var string
 		 */
 		$type = self::OBJECT_CLASS_NAMESPACE . 'user';
+
+		/**
+		 * Allows the theme to overwrite class that is going to be used to create a user.
+		 *
+		 * @hook clarkson_user_type
+		 * @since 1.0.0
+		 * @param {null|string} $type Sanitized class name.
+		 * @param {\WP_User} $user Sanitized class name.
+		 * @return {null|string} Class name of user to be created.
+		 *
+		 * @example
+		 * // load a different class instead of what Clarkson Core calculates.
+		 * add_filter( 'clarkson_user_type', function( $type, $user ) {
+		 *  if ( user_can( $user, 'read' ) ){
+		 *      $type = self::OBJECT_CLASS_NAMESPACE . 'custom_user_class';
+		 *  }
+		 *  return $type;
+		 * }, 10, 2 );
+		 */
+		$type = apply_filters( 'clarkson_user_type', $type, $user );
 
 		if ( class_exists( $type ) ) {
 			$user_object = new $type( $user );

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -55,7 +55,7 @@ class Objects {
 		 * @hook clarkson_term_types
 		 * @since 1.0.0
 		 * @param {array} $typse Sanitized class names to load.
-		 * @param {\WP_Term} $term Term which we are trying to convert into an object.
+		 * @param {WP_Term} $term Term which we are trying to convert into an object.
 		 * @return {array} Class names to search for.
 		 *
 		 * @example
@@ -117,7 +117,7 @@ class Objects {
 		 * @hook clarkson_user_type
 		 * @since 1.0.0
 		 * @param {null|string} $type Sanitized class name.
-		 * @param {\WP_User} $user Sanitized class name.
+		 * @param {WP_User} $user Sanitized class name.
 		 * @return {null|string} Class name of user to be created.
 		 *
 		 * @example
@@ -198,7 +198,7 @@ class Objects {
 		 * @hook clarkson_object_type
 		 * @since 0.1.1
 		 * @param {null|string} $type Sanitized class name.
-		 * @param {\WP_Post} $post Sanitized class name.
+		 * @param {WP_Post} $post Sanitized class name.
 		 * @return {null|string} Class name of object to be created.
 		 *
 		 * @example

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -5,11 +5,17 @@
  * @package CLARKSON\Lib
  */
 
+namespace Clarkson_Core;
+
+use Clarkson_Core\Object\Clarkson_Object;
+use Clarkson_Core\Object\Clarkson_Term;
+use Clarkson_Core\Object\Clarkson_User;
+
 /**
  * This class is used to convert WordPress posts, terms and users into Clarkson
  * Objects.
  */
-class Clarkson_Core_Objects {
+class Objects {
 
 	/**
 	 * Clarkson Core Objects array.
@@ -23,16 +29,16 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_Term $term The term.
 	 *
-	 * @return \Clarkson_Term
+	 * @return Clarkson_Term
 	 */
-	public function get_term( \WP_Term $term ): \Clarkson_Term {
-		$cc         = Clarkson_Core::get_instance();
+	public function get_term( \WP_Term $term ): Clarkson_Term {
+		$cc         = \Clarkson_Core::get_instance();
 		$class_name = $cc->autoloader->sanitize_object_name( $term->taxonomy );
 
 		if ( in_array( $class_name, $cc->autoloader->taxonomies, true ) && class_exists( $class_name ) ) {
 			return new $class_name( $term );
 		}
-		return new \Clarkson_Term( $term );
+		return new Clarkson_Term( $term );
 	}
 
 	/**
@@ -40,7 +46,7 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_User[] $users array of \WP_User objects.
 	 *
-	 * @return \Clarkson_User[]
+	 * @return Clarkson_User[]
 	 */
 	public function get_users( array $users ): array {
 		$user_objects = array();
@@ -60,10 +66,10 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_User $user WP_User object.
 	 *
-	 * @return \Clarkson_User
+	 * @return Clarkson_User
 	 */
-	public function get_user( \WP_User $user ): \Clarkson_User {
-		$cc         = Clarkson_Core::get_instance();
+	public function get_user( \WP_User $user ): Clarkson_User {
+		$cc         = \Clarkson_Core::get_instance();
 		$class_name = false;
 
 		if ( $user->roles && count( $user->roles ) >= 1 ) {
@@ -84,7 +90,7 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_Post[] $posts Posts.
 	 *
-	 * @return \Clarkson_Object[] $objects Array of post objects.
+	 * @return Clarkson_Object[] $objects Array of post objects.
 	 */
 	public function get_objects( array $posts ): array {
 		$objects = array();
@@ -101,10 +107,10 @@ class Clarkson_Core_Objects {
 	 *
 	 * @param \WP_Post $post Post.
 	 *
-	 * @return \Clarkson_Object Clarkson Post object.
+	 * @return Clarkson_Object Clarkson Post object.
 	 */
-	public function get_object( \WP_Post $post ): \Clarkson_Object {
-		$cc = Clarkson_Core::get_instance();
+	public function get_object( \WP_Post $post ): Clarkson_Object {
+		$cc = \Clarkson_Core::get_instance();
 
 		// defaults to post type.
 		$type = get_post_type( $post );
@@ -194,20 +200,20 @@ class Clarkson_Core_Objects {
 	/**
 	 * Get the instance.
 	 *
-	 * @return Clarkson_Core_Objects
+	 * @return \Clarkson_Core\Objects
 	 */
-	public static function get_instance(): \Clarkson_Core_Objects {
+	public static function get_instance(): \Clarkson_Core\Objects {
 		static $instance = null;
 
 		if ( null === $instance ) {
-			$instance = new Clarkson_Core_Objects();
+			$instance = new self();
 		}
 
 		return $instance;
 	}
 
 	/**
-	 * Clarkson_Core_Objects constructor.
+	 * \Clarkson_Core\Objects constructor.
 	 */
 	protected function __construct() {
 		$this->register_objects();

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -16,14 +16,6 @@ use Clarkson_Core\Object\Clarkson_User;
  * Objects.
  */
 class Objects {
-
-	/**
-	 * Clarkson Core Objects array.
-	 *
-	 * @var array $objects Clarkson_Core_Objects.
-	 */
-	protected $objects = array();
-
 	/**
 	 * Get term data.
 	 *
@@ -189,20 +181,6 @@ class Objects {
 	}
 
 	/**
-	 * Register objects.
-	 */
-	private function register_objects():void {
-		$objects = array(
-			'Clarkson_Object' => '',
-			'Clarkson_Term'   => '',
-			'Clarkson_User'   => '',
-		);
-
-		$this->objects = $objects;
-	}
-
-
-	/**
 	 * Singleton.
 	 *
 	 * @var null|\Clarkson_Core\Objects $instance The Clarkson core objects.
@@ -220,13 +198,6 @@ class Objects {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * \Clarkson_Core\Objects constructor.
-	 */
-	protected function __construct() {
-		$this->register_objects();
 	}
 
 	/**

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -29,7 +29,7 @@ class Objects {
 
 		if ( in_array( $class_name, $cc->autoloader->taxonomies, true ) && class_exists( $class_name ) ) {
 			$term_object = new $class_name( $term );
-			if($term_object instanceof Clarkson_Term){
+			if ( $term_object instanceof Clarkson_Term ) {
 				return $term_object;
 			}
 		}
@@ -73,7 +73,7 @@ class Objects {
 
 		if ( $class_name && in_array( $class_name, $cc->autoloader->user_types, true ) && class_exists( $class_name ) ) {
 			$user_object = new $class_name( $user );
-			if($user_object instanceof Clarkson_User){
+			if ( $user_object instanceof Clarkson_User ) {
 				return $user_object;
 			}
 		}
@@ -117,7 +117,7 @@ class Objects {
 			$type = $page_template_slug;
 		}
 
-		if(empty($type)){
+		if ( empty( $type ) ) {
 			$type = '';
 		}
 
@@ -166,14 +166,14 @@ class Objects {
 		$object_creation_callback = apply_filters( 'clarkson_core_create_object_callback', false, $type, $post->ID );
 		if ( is_callable( $object_creation_callback ) ) {
 			$clarkson_object = call_user_func_array( $object_creation_callback, array( $post->ID ) );
-			if($clarkson_object instanceof Clarkson_Object){
+			if ( $clarkson_object instanceof Clarkson_Object ) {
 				return $clarkson_object;
 			}
 		}
 
 		if ( ( in_array( $type, $cc->autoloader->post_types, true ) || in_array( $type, $cc->autoloader->extra, true ) ) && class_exists( $type ) ) {
 			$clarkson_object = new $type( $post );
-			if($clarkson_object instanceof Clarkson_Object){
+			if ( $clarkson_object instanceof Clarkson_Object ) {
 				return $clarkson_object;
 			}
 		}

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -19,6 +19,23 @@ use DomainException;
 class Objects {
 	const OBJECT_CLASS_NAMESPACE = '\\Clarkson_Core\\Object\\';
 	/**
+	 * Convert WP_Term object to a Clarkson Object.
+	 *
+	 * @param \WP_Term[] $terms array of \WP_Term objects.
+	 *
+	 * @return Clarkson_Term[]
+	 */
+	public function get_terms( array $terms ): array {
+		$term_objects = array();
+
+		foreach ( $terms as $term ) {
+			$term_objects[] = $this->get_term( $term );
+		}
+
+		return $term_objects;
+	}
+
+	/**
 	 * Get term data.
 	 *
 	 * @param \WP_Term $term The term.
@@ -45,7 +62,7 @@ class Objects {
 	}
 
 	/**
-	 * Get users by id.
+	 * Convert WP_User object to a Clarkson Object.
 	 *
 	 * @param \WP_User[] $users array of \WP_User objects.
 	 *

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -32,7 +32,7 @@ class Objects {
 	 * @return Clarkson_Term
 	 */
 	public function get_term( \WP_Term $term ): Clarkson_Term {
-		$cc         = \Clarkson_Core::get_instance();
+		$cc         = Clarkson_Core::get_instance();
 		$class_name = $cc->autoloader->sanitize_object_name( $term->taxonomy );
 
 		if ( in_array( $class_name, $cc->autoloader->taxonomies, true ) && class_exists( $class_name ) ) {
@@ -69,7 +69,7 @@ class Objects {
 	 * @return Clarkson_User
 	 */
 	public function get_user( \WP_User $user ): Clarkson_User {
-		$cc         = \Clarkson_Core::get_instance();
+		$cc         = Clarkson_Core::get_instance();
 		$class_name = false;
 
 		if ( $user->roles && count( $user->roles ) >= 1 ) {
@@ -110,7 +110,7 @@ class Objects {
 	 * @return Clarkson_Object Clarkson Post object.
 	 */
 	public function get_object( \WP_Post $post ): Clarkson_Object {
-		$cc = \Clarkson_Core::get_instance();
+		$cc = Clarkson_Core::get_instance();
 
 		// defaults to post type.
 		$type = get_post_type( $post );

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -5,7 +5,9 @@
  * @package CLARKSON\Lib
  */
 
-class Clarkson_Core_Template_Context {
+namespace Clarkson_Core;
+
+class Template_Context {
 
 	/**
 	 * Register all hooks to add context to the template call.
@@ -22,7 +24,7 @@ class Clarkson_Core_Template_Context {
 	 */
 	public function add_author( array $context, \WP_Query $wp_query ): array {
 		if ( $wp_query->is_author ) {
-			$object_loader = Clarkson_Core_Objects::get_instance();
+			$object_loader = Objects::get_instance();
 			$object        = $wp_query->queried_object;
 			if ( $object instanceof \WP_User ) {
 				$author            = $object_loader->get_user( $object );
@@ -38,7 +40,7 @@ class Clarkson_Core_Template_Context {
 	 */
 	public function add_term( array $context, \WP_Query $wp_query ):array {
 		if ( $wp_query->is_tax ) {
-			$object_loader = Clarkson_Core_Objects::get_instance();
+			$object_loader = Objects::get_instance();
 			$term          = $wp_query->queried_object;
 			if ( $term instanceof \WP_Term ) {
 				$context['term'] = $object_loader->get_term( $term );
@@ -61,7 +63,7 @@ class Clarkson_Core_Template_Context {
 	 * Adds posts to the current context.
 	 */
 	public function add_posts( array $context, \WP_Query $wp_query ):array {
-		$object_loader      = Clarkson_Core_Objects::get_instance();
+		$object_loader      = Objects::get_instance();
 		$context['objects'] = $object_loader->get_objects( $wp_query->posts );
 		return $context;
 	}

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -39,7 +39,7 @@ class Template_Context {
 	 * Adds a term if the current request is a term archive.
 	 */
 	public function add_term( array $context, \WP_Query $wp_query ):array {
-		if ( $wp_query->is_tax ) {
+		if ( $wp_query->is_tax || $wp_query->is_category || $wp_query->is_tag ) {
 			$object_loader = Objects::get_instance();
 			$term          = $wp_query->queried_object;
 			if ( $term instanceof \WP_Term ) {

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -12,7 +12,7 @@ class Template_Context {
 	/**
 	 * Register all hooks to add context to the template call.
 	 */
-	public function register_hooks() {
+	public function register_hooks():void {
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_author' ), 10, 2 );
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_term' ), 10, 2 );
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_search_count' ), 10, 2 );

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -273,7 +273,7 @@ class Templates {
 			 * @hook clarkson_core_template_context
 			 * @since 1.0.0
 			 * @param {array} $context The context that will be passed onto the template.
-			 * @param {\WP_Query} $wp_query The current query that is being rendered.
+			 * @param {WP_Query} $wp_query The current query that is being rendered.
 			 * @return {array} The context that will be passed onto the template.
 			 *
 			 * @example

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -414,7 +414,7 @@ class Templates {
 	 *
 	 * @var null instance Templates.
 	 */
-	protected $instance = null;
+	protected static $instance = null;
 
 	/**
 	 * Get instance.
@@ -422,11 +422,10 @@ class Templates {
 	 * @return Templates
 	 */
 	public static function get_instance() {
-		static $instance = null;
-		if ( null === $instance ) {
-			$instance = new Templates();
+		if ( null === self::$instance ) {
+			self::$instance = new Templates();
 		}
-		return $instance;
+		return self::$instance;
 	}
 
 	public function add_twig_to_template_hierarchy( array $original_templates ):array {
@@ -454,9 +453,6 @@ class Templates {
 	 * Clarkson_Core_Templates constructor.
 	 */
 	protected function __construct() {
-		if ( ! class_exists( 'Clarkson_Core_Objects' ) ) {
-			return;
-		}
 		foreach ( self::TEMPLATE_TYPES as $template_type ) {
 			add_filter( $template_type . '_template_hierarchy', array( $this, 'add_twig_to_template_hierarchy' ), 999 );
 		}

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -303,7 +303,7 @@ class Templates {
 	 */
 	public function get_templates( $choices = array() ) {
 		$templates = wp_cache_get( 'templates', 'clarkson_core' );
-		if ( is_array($templates) ) {
+		if ( is_array( $templates ) ) {
 			return $templates;
 		}
 		$templates      = $choices;
@@ -489,7 +489,7 @@ class Templates {
 				$post_types = array_merge( $custom_post_types, $builtin_post_types );
 
 				foreach ( $post_types as $post_type ) {
-					if(is_string($post_type)){
+					if ( is_string( $post_type ) ) {
 						add_filter( 'theme_' . $post_type . '_templates', array( $this, 'add_new_template' ), 10, 4 );
 					}
 				}

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -412,7 +412,7 @@ class Templates {
 	/**
 	 * Singleton.
 	 *
-	 * @var null instance Templates.
+	 * @var Templates|null instance Templates.
 	 */
 	protected static $instance = null;
 

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -5,10 +5,12 @@
  * @package CLARKSON\Lib
  */
 
+namespace Clarkson_Core;
+
 /**
  * Allows rendering of specific templates with Twig.
  */
-class Clarkson_Core_Templates {
+class Templates {
 	/**
 	 * The template types, are all seperate `get_query_template` can be called with.
 	 *
@@ -40,7 +42,7 @@ class Clarkson_Core_Templates {
 	 *
 	 * This object can be used if you want to remove any of the default add_filters.
 	 *
-	 * @var \Clarkson_Core_Template_Context
+	 * @var \Clarkson_Core\Template_Context
 	 */
 	public $template_context;
 
@@ -105,17 +107,17 @@ class Clarkson_Core_Templates {
 		 * } );
 		 */
 		$twig_args = apply_filters( 'clarkson_twig_args', $twig_args );
-		$twig_fs   = new Twig_Loader_Filesystem( $template_dirs );
-		$twig      = new Twig_Environment( $twig_fs, $twig_args );
+		$twig_fs   = new \Twig_Loader_Filesystem( $template_dirs );
+		$twig      = new \Twig_Environment( $twig_fs, $twig_args );
 
-		$twig->addExtension( new Clarkson_Core_Twig_Extension() );
-		$twig->addExtension( new Twig_Extensions_Extension_I18n() );
-		$twig->addExtension( new Twig_Extensions_Extension_Text() );
-		$twig->addExtension( new Twig_Extensions_Extension_Array() );
-		$twig->addExtension( new Twig_Extensions_Extension_Date() );
+		$twig->addExtension( new Twig_Extension() );
+		$twig->addExtension( new \Twig_Extensions_Extension_I18n() );
+		$twig->addExtension( new \Twig_Extensions_Extension_Text() );
+		$twig->addExtension( new \Twig_Extensions_Extension_Array() );
+		$twig->addExtension( new \Twig_Extensions_Extension_Date() );
 
 		if ( $debug ) {
-			$twig->addExtension( new Twig_Extension_Debug() );
+			$twig->addExtension( new \Twig_Extension_Debug() );
 		}
 
 		/**
@@ -410,19 +412,19 @@ class Clarkson_Core_Templates {
 	/**
 	 * Singleton.
 	 *
-	 * @var null instance Clarkson_Core_Templates.
+	 * @var null instance Templates.
 	 */
 	protected $instance = null;
 
 	/**
 	 * Get instance.
 	 *
-	 * @return Clarkson_Core_Templates
+	 * @return Templates
 	 */
 	public static function get_instance() {
 		static $instance = null;
 		if ( null === $instance ) {
-			$instance = new Clarkson_Core_Templates();
+			$instance = new Templates();
 		}
 		return $instance;
 	}
@@ -452,7 +454,6 @@ class Clarkson_Core_Templates {
 	 * Clarkson_Core_Templates constructor.
 	 */
 	protected function __construct() {
-		require_once __DIR__ . '/clarkson-core-template-context.php';
 		if ( ! class_exists( 'Clarkson_Core_Objects' ) ) {
 			return;
 		}
@@ -460,7 +461,7 @@ class Clarkson_Core_Templates {
 			add_filter( $template_type . '_template_hierarchy', array( $this, 'add_twig_to_template_hierarchy' ), 999 );
 		}
 
-		$this->template_context = new Clarkson_Core_Template_Context();
+		$this->template_context = new Template_Context();
 		$this->template_context->register_hooks();
 
 		add_action( 'template_include', array( $this, 'template_include' ) );

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -61,7 +61,7 @@ class Templates {
 	 * @param bool   $ignore_warning Ignore multiple render warning.
 	 * @internal
 	 */
-	public function render( $path, $objects, $ignore_warning = false ) {
+	public function render( $path, $objects, $ignore_warning = false ):void {
 		$this->echo_twig( $path, $objects, $ignore_warning );
 		exit();
 	}
@@ -166,7 +166,7 @@ class Templates {
 	 * @param array  $objects        Post objects.
 	 * @param bool   $ignore_warning Ignore multiple render warning.
 	 */
-	public function echo_twig( $template_file, $objects, $ignore_warning = false ) {
+	public function echo_twig( $template_file, $objects, $ignore_warning = false ):void {
 		echo $this->render_twig( $template_file, $objects, $ignore_warning );
 	}
 
@@ -175,7 +175,7 @@ class Templates {
 	 *
 	 * This takes notices of the child / parent hierarchy, so that's why the child theme gets searched first and then the parent theme, just like the regular WordPress templating hierarchy.
 	 */
-	public function get_templates_dirs() {
+	public function get_templates_dirs():array {
 		$template_dirs = array(
 			$this->get_stylesheet_dir(),
 			$this->get_template_dir(),
@@ -215,7 +215,7 @@ class Templates {
 	/**
 	 * Retrieves the parent theme directory Clarkson Core is using to find templates.
 	 */
-	public function get_template_dir() {
+	public function get_template_dir():string {
 		/**
 		 * Modify the template directory path.
 		 *
@@ -230,13 +230,13 @@ class Templates {
 		 *  return get_template_directory() . '/twig_templates';
 		 * } );
 		 */
-		return realpath( apply_filters( 'clarkson_twig_template_dir', get_template_directory() . '/templates' ) );
+		return (string) realpath( apply_filters( 'clarkson_twig_template_dir', get_template_directory() . '/templates' ) );
 	}
 
 	/**
 	 * Gets the stylesheet directory Clarkson Core is using to find twig templates.
 	 */
-	public function get_stylesheet_dir() {
+	public function get_stylesheet_dir():string {
 		/**
 		 * Modify the template directory path for the stylesheet directory.
 		 *
@@ -251,7 +251,7 @@ class Templates {
 		 *  return get_stylesheet_directory() . '/twig_templates';
 		 * } );
 		 */
-		return realpath( apply_filters( 'clarkson_twig_stylesheet_dir', get_stylesheet_directory() . '/templates' ) );
+		return (string) realpath( apply_filters( 'clarkson_twig_stylesheet_dir', get_stylesheet_directory() . '/templates' ) );
 	}
 
 	/**
@@ -298,12 +298,12 @@ class Templates {
 	 *
 	 * @param array $choices Choices.
 	 *
-	 * @return array|bool|mixed
+	 * @return array
 	 * @internal
 	 */
 	public function get_templates( $choices = array() ) {
 		$templates = wp_cache_get( 'templates', 'clarkson_core' );
-		if ( $templates ) {
+		if ( is_array($templates) ) {
 			return $templates;
 		}
 		$templates      = $choices;
@@ -365,7 +365,7 @@ class Templates {
 	/**
 	 * Add template filters.
 	 */
-	private function get_template_files() {
+	private function get_template_files():array {
 		// Get template files.
 		$template_paths = $this->get_templates_dirs();
 
@@ -398,8 +398,8 @@ class Templates {
 	 *
 	 * @return array
 	 */
-	private function get_templates_from_path( $path ) {
-		if ( ! $path || ! is_string( $path ) || ! file_exists( $path ) ) {
+	private function get_templates_from_path( string $path ) {
+		if ( ! $path || ! file_exists( $path ) ) {
 			return array();
 		}
 		$files = glob( "{$path}/template-*.twig" );
@@ -429,7 +429,7 @@ class Templates {
 		return $instance;
 	}
 
-	public function add_twig_to_template_hierarchy( array $original_templates ) {
+	public function add_twig_to_template_hierarchy( array $original_templates ):array {
 		$templates = array();
 
 		$directories = array_unique(
@@ -493,7 +493,9 @@ class Templates {
 				$post_types = array_merge( $custom_post_types, $builtin_post_types );
 
 				foreach ( $post_types as $post_type ) {
-					add_filter( 'theme_' . $post_type . '_templates', array( $this, 'add_new_template' ), 10, 4 );
+					if(is_string($post_type)){
+						add_filter( 'theme_' . $post_type . '_templates', array( $this, 'add_new_template' ), 10, 4 );
+					}
 				}
 			}
 		);

--- a/src/Twig_Extension.php
+++ b/src/Twig_Extension.php
@@ -5,11 +5,13 @@
  * @package CLARKSON\Lib
  */
 
+namespace Clarkson_Core;
+
 /**
- * Class Clarkson_Core_Twig_Extension.
+ * Class Clarkson_Core\Twig_Extension.
  * @internal
  */
-class Clarkson_Core_Twig_Extension extends Twig_Extension {
+class Twig_Extension extends \Twig_Extension {
 
 	/**
 	 * Twig functions.
@@ -950,7 +952,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 	);
 
 	/**
-	 * Clarkson_Core_Twig_Extension constructor.
+	 * Clarkson_Core\Twig_Extension constructor.
 	 *
 	 * @param array $functions WordPress functions.
 	 */
@@ -963,7 +965,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 	/**
 	 * Get the Twig functions.
 	 *
-	 * @return Twig_SimpleFunction[] $twig_functions Twig functions.
+	 * @return \Twig_SimpleFunction[] $twig_functions Twig functions.
 	 * @internal
 	 */
 	public function getFunctions() {
@@ -988,7 +990,7 @@ class Clarkson_Core_Twig_Extension extends Twig_Extension {
 		$allowed_functions = apply_filters( 'clarkson_twig_functions', $this->functions );
 
 		foreach ( $allowed_functions  as $function ) {
-			$twig_functions[] = new Twig_SimpleFunction( $function, $function );
+			$twig_functions[] = new \Twig_SimpleFunction( $function, $function );
 		}
 
 		return $twig_functions;

--- a/src/Twig_Extension.php
+++ b/src/Twig_Extension.php
@@ -1000,6 +1000,7 @@ class Twig_Extension extends \Twig_Extension {
 	 * Add an allowed function to Twig function.
 	 *
 	 * @param string $function Twig function name.
+	 * @return void
 	 */
 	public function allowFunction( $function ) {
 		$this->functions[] = $function;
@@ -1009,6 +1010,7 @@ class Twig_Extension extends \Twig_Extension {
 	 * Set allowd functions allowed in Twig.
 	 *
 	 * @param array $functions Allowed Twig functions.
+	 * @return void
 	 */
 	public function allowFunctions( array $functions ) {
 		$this->functions = $functions;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,11 @@
 <?php
 
 // First we need to load the composer autoloader so we can use WP Mock.
+
+use Clarkson_Core\Object\Clarkson_Object;
+use Clarkson_Core\Object\Clarkson_Term;
+use Clarkson_Core\Object\Clarkson_User;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 // Now call the bootstrap method of WP Mock.
@@ -22,6 +27,6 @@ class WP_Block_Type{}
 /**
  * Test classes for custom type castings.
  */
-class user_test_role extends \Clarkson_User{}; //phpcs:ignore
-class custom_test_tax extends \Clarkson_Term{}; //phpcs:ignore
-class test_overwritten_object_creation extends \Clarkson_Object{}; //phpcs:ignore
+class user_test_role extends Clarkson_User{}; //phpcs:ignore
+class custom_test_tax extends Clarkson_Term{}; //phpcs:ignore
+class test_overwritten_object_creation extends Clarkson_Object{}; //phpcs:ignore

--- a/tests/custom_test_template.php
+++ b/tests/custom_test_template.php
@@ -3,4 +3,4 @@
 /**
  * This file is used to test cutom templated objects.
  */
-class custom_test_template extends \Clarkson_Object{}; //phpcs:ignore
+class custom_test_template extends \Clarkson_Core\Object\Clarkson_Object{}; //phpcs:ignore

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,10 +1,10 @@
 <?php
 
+use Clarkson_Core\Clarkson_Core;
 use Clarkson_Core\Object\Clarkson_Object;
 use Clarkson_Core\Object\Clarkson_Term;
 use Clarkson_Core\Object\Clarkson_User;
 use Clarkson_Core\Objects;
-use WP_Mock\Functions;
 
 class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	public function setUp():void {

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,6 +1,5 @@
 <?php
 
-use Clarkson_Core\Clarkson_Core;
 use Clarkson_Core\Object\Clarkson_Object;
 use Clarkson_Core\Object\Clarkson_Term;
 use Clarkson_Core\Object\Clarkson_User;
@@ -57,20 +56,6 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	/**
 	 * @depends test_can_get_instance
 	 */
-	public function test_can_get_custom_page_template( $cc_objects ) {
-		$post     = Mockery::mock( '\WP_Post' );
-		$post->ID = 1;
-		\WP_Mock::userFunction( 'get_post_type', 'page' );
-		\WP_Mock::userFunction( 'get_page_template_slug' )->andReturn( 'custom_test_template.php' );
-
-		$cc                         = Clarkson_Core::get_instance();
-		$cc->autoloader->post_types = array( 'custom_test_template' );
-		$this->assertContainsOnlyInstancesOf( \custom_test_template::class, $cc_objects->get_objects( array( $post ) ) );
-	}
-
-	/**
-	 * @depends test_can_get_instance
-	 */
 	public function test_can_get_term( $cc_objects ) {
 		$term           = Mockery::mock( '\WP_Term' );
 		$term->term_id  = 1;
@@ -83,36 +68,9 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	/**
 	 * @depends test_can_get_instance
 	 */
-	public function test_can_get_term_cast_to_custom_object( $cc_objects ) {
-		$term           = Mockery::mock( '\WP_Term' );
-		$term->term_id  = 1;
-		$term->taxonomy = 'custom_test_tax';
-		\WP_Mock::userFunction( 'get_term_by' )->andReturn( $term );
-		\WP_Mock::userFunction( 'get_term' )->andReturn( $term );
-
-		$cc                         = Clarkson_Core::get_instance();
-		$cc->autoloader->taxonomies = array( 'custom_test_tax' );
-		$this->assertInstanceOf( \custom_test_tax::class, $cc_objects->get_term( $term ) );
-	}
-
-	/**
-	 * @depends test_can_get_instance
-	 */
 	public function test_can_get_users( $cc_objects ) {
 		$user        = Mockery::mock( '\WP_User' );
 		$user->roles = array( 'administrator' );
 		$this->assertContainsOnlyInstancesOf( Clarkson_User::class, $cc_objects->get_users( array( $user ) ) );
-	}
-
-	/**
-	 * @depends test_can_get_instance
-	 */
-	public function test_casts_user_to_custom_object( $cc_objects ) {
-		$user        = Mockery::mock( '\WP_User' );
-		$user->roles = array( 'test_role' );
-
-		$cc                         = Clarkson_Core::get_instance();
-		$cc->autoloader->user_types = array( 'user_test_role' );
-		$this->assertInstanceOf( \user_test_role::class, $cc_objects->get_user( $user ) );
 	}
 }

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,5 +1,9 @@
 <?php
 
+use Clarkson_Core\Object\Clarkson_Object;
+use Clarkson_Core\Object\Clarkson_Term;
+use Clarkson_Core\Object\Clarkson_User;
+use Clarkson_Core\Objects;
 use WP_Mock\Functions;
 
 class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
@@ -13,8 +17,8 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 
 	public function test_can_get_instance() {
 		\WP_Mock::userFunction( 'get_template_directory', '/tmp/wp-content/themes/theme/' );
-		$cc_templates = \Clarkson_Core_Objects::get_instance();
-		$this->assertInstanceOf( \Clarkson_Core_Objects::class, $cc_templates );
+		$cc_templates = Objects::get_instance();
+		$this->assertInstanceOf( Objects::class, $cc_templates );
 		return $cc_templates;
 	}
 
@@ -26,7 +30,7 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		$post->ID = 1;
 		\WP_Mock::userFunction( 'get_post_type', 'post' );
 		\WP_Mock::userFunction( 'get_page_template_slug', '' );
-		$this->assertContainsOnlyInstancesOf( \Clarkson_Object::class, $cc_objects->get_objects( array( $post ) ) );
+		$this->assertContainsOnlyInstancesOf( Clarkson_Object::class, $cc_objects->get_objects( array( $post ) ) );
 	}
 
 	/**
@@ -47,7 +51,7 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		\WP_Mock::userFunction( 'get_post' )->andReturn( $post );
 		\WP_Mock::userFunction( 'get_post_type', 'post' );
 		\WP_Mock::userFunction( 'get_page_template_slug', '' );
-		$this->assertInstanceOf( \Clarkson_Object::class, $cc_objects->get_object( $post ) );
+		$this->assertInstanceOf( Clarkson_Object::class, $cc_objects->get_object( $post ) );
 	}
 
 	/**
@@ -73,7 +77,7 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 		$term->taxonomy = 'category';
 		\WP_Mock::userFunction( 'get_term_by' )->andReturn( $term );
 		\WP_Mock::userFunction( 'get_term' )->andReturn( $term );
-		$this->assertInstanceOf( \Clarkson_Term::class, $cc_objects->get_term( $term ) );
+		$this->assertInstanceOf( Clarkson_Term::class, $cc_objects->get_term( $term ) );
 	}
 
 	/**
@@ -97,7 +101,7 @@ class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {
 	public function test_can_get_users( $cc_objects ) {
 		$user        = Mockery::mock( '\WP_User' );
 		$user->roles = array( 'administrator' );
-		$this->assertContainsOnlyInstancesOf( \Clarkson_User::class, $cc_objects->get_users( array( $user ) ) );
+		$this->assertContainsOnlyInstancesOf( Clarkson_User::class, $cc_objects->get_users( array( $user ) ) );
 	}
 
 	/**

--- a/tests/lib/clarkson-core-templates.test.php
+++ b/tests/lib/clarkson-core-templates.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Clarkson_Core\Templates;
+
 class ClarksonCoreTemplatesTest extends \WP_Mock\Tools\TestCase {
 	public function setUp():void {
 		\WP_Mock::setUp();
@@ -13,8 +15,8 @@ class ClarksonCoreTemplatesTest extends \WP_Mock\Tools\TestCase {
 		\WP_Mock::userFunction( 'get_template_directory', '/tmp/wp-content/themes/theme/' );
 		\WP_Mock::userFunction( 'get_stylesheet_directory', '/tmp/wp-content/themes/child-theme/' );
 		\WP_Mock::userFunction( 'get_bloginfo' )->with( 'version' )->andReturn( '4.7' );
-		$cc_templates = \Clarkson_Core_Templates::get_instance();
-		$this->assertInstanceOf( \Clarkson_Core_Templates::class, $cc_templates );
+		$cc_templates = Templates::get_instance();
+		$this->assertInstanceOf( Templates::class, $cc_templates );
 		return $cc_templates;
 	}
 }

--- a/tests/wordpress-objects/Clarkson_Object.test.php
+++ b/tests/wordpress-objects/Clarkson_Object.test.php
@@ -1,5 +1,8 @@
 <?php
 
+use Clarkson_Core\Object\Clarkson_Object;
+use Clarkson_Core\Object\Clarkson_Term;
+
 class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
@@ -17,8 +20,8 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 	public function test_can_construct_an_object() {
 		$post     = Mockery::mock( '\WP_Post' );
 		$post->ID = self::POST_ID;
-		$object   = new \Clarkson_Object( $post );
-		$this->assertInstanceOf( \Clarkson_Object::class, $object );
+		$object   = new Clarkson_Object( $post );
+		$this->assertInstanceOf( Clarkson_Object::class, $object );
 		return $object;
 	}
 
@@ -27,7 +30,7 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 		$post->ID = self::POST_ID;
 		\WP_Mock::userFunction( '_doing_it_wrong' );
 		\WP_Mock::userFunction( 'get_post' )->andReturn( $post );
-		new \Clarkson_Object( self::POST_ID );
+		new Clarkson_Object( self::POST_ID );
 	}
 
 	/**
@@ -41,7 +44,7 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 		\WP_Mock::userFunction( 'is_wp_error', false );
 		\WP_Mock::userFunction( 'get_term_by' )->with( 'id', self::TERM_ID, 'category' )->andReturn( $term );
 		\WP_Mock::userFunction( 'get_term' )->with( self::TERM_ID, 'category' )->andReturn( $term );
-		$this->assertContainsOnlyInstancesOf( \Clarkson_Term::class, $object->get_terms( 'category' ) );
+		$this->assertContainsOnlyInstancesOf( Clarkson_Term::class, $object->get_terms( 'category' ) );
 	}
 
 	/**

--- a/tests/wordpress-objects/Clarkson_Object.test.php
+++ b/tests/wordpress-objects/Clarkson_Object.test.php
@@ -25,14 +25,6 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 		return $object;
 	}
 
-	public function test_can_construct_an_object_with_id() {
-		$post     = Mockery::mock( '\WP_Post' );
-		$post->ID = self::POST_ID;
-		\WP_Mock::userFunction( '_doing_it_wrong' );
-		\WP_Mock::userFunction( 'get_post' )->andReturn( $post );
-		new Clarkson_Object( self::POST_ID );
-	}
-
 	/**
 	 * @depends test_can_construct_an_object
 	 */

--- a/tests/wordpress-objects/Clarkson_User.test.php
+++ b/tests/wordpress-objects/Clarkson_User.test.php
@@ -19,25 +19,4 @@ class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
 		$this->assertInstanceOf( Clarkson_User::class, $object );
 		return $object;
 	}
-
-	public function test_can_construct_a_user_with_fallback() {
-		$user        = Mockery::mock( '\WP_User' );
-		$user->roles = array( 'administrator' );
-		\WP_Mock::userFunction( '_doing_it_wrong' );
-		\WP_Mock::userFunction( 'get_userdata' )->with( 1 )->andReturn( $user );
-		$object = new Clarkson_User( 1 );
-		$this->assertInstanceOf( Clarkson_User::class, $object );
-	}
-
-	public function test_throw_construct_user_with_invalid_id() {
-		\WP_Mock::userFunction( '_doing_it_wrong' );
-		\WP_Mock::userFunction( 'get_userdata' )->with( -1 )->andReturn( false );
-		$this->expectException( '\Exception' );
-		new Clarkson_User( -1 );
-	}
-
-	public function test_throw_construct_user_with_empty() {
-		$this->expectException( '\Exception' );
-		new Clarkson_User( '' );
-	}
 }

--- a/tests/wordpress-objects/Clarkson_User.test.php
+++ b/tests/wordpress-objects/Clarkson_User.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Clarkson_Core\Object\Clarkson_User;
+
 class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
@@ -13,8 +15,8 @@ class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
 
 	public function test_can_construct_a_user() {
 		$user   = Mockery::mock( '\WP_User' );
-		$object = new \Clarkson_User( $user );
-		$this->assertInstanceOf( \Clarkson_User::class, $object );
+		$object = new Clarkson_User( $user );
+		$this->assertInstanceOf( Clarkson_User::class, $object );
 		return $object;
 	}
 
@@ -23,19 +25,19 @@ class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
 		$user->roles = array( 'administrator' );
 		\WP_Mock::userFunction( '_doing_it_wrong' );
 		\WP_Mock::userFunction( 'get_userdata' )->with( 1 )->andReturn( $user );
-		$object = new \Clarkson_User( 1 );
-		$this->assertInstanceOf( \Clarkson_User::class, $object );
+		$object = new Clarkson_User( 1 );
+		$this->assertInstanceOf( Clarkson_User::class, $object );
 	}
 
 	public function test_throw_construct_user_with_invalid_id() {
 		\WP_Mock::userFunction( '_doing_it_wrong' );
 		\WP_Mock::userFunction( 'get_userdata' )->with( -1 )->andReturn( false );
 		$this->expectException( '\Exception' );
-		new \Clarkson_User( -1 );
+		new Clarkson_User( -1 );
 	}
 
 	public function test_throw_construct_user_with_empty() {
 		$this->expectException( '\Exception' );
-		new \Clarkson_User( '' );
+		new Clarkson_User( '' );
 	}
 }


### PR DESCRIPTION
There are some issues in Clarkson Core that have to do with having the right objects available at the right moment. See #142 and #161 for some examples. This is caused by the custom object discovery and loading logic used in Clarkson Core.

This change set remodels Clarkson Core's loading into a psr-4 model. This means the following:

- All `Clarkson_Core_*` class names are now brought into a new `Clarkson_Core` namespace.
- The class-map is gone, all files are now psr-4 auto-loaded.
- The custom autoloader for Clarkson Core is going to disappear. Objects defined in the theme are going to be auto loaded with a namespace.
- There is now an object hierarchy:
    * Objects: `\Clarkson_Core\Object\$template`, `\Clarkson_Core\Object\$post_type`, `\Clarkson_Core\Object\base_object`, `\Clarkson_Core\Object\Clarkson_Object`
    * Terms: `\Clarkson_Core\Object\$taxonomy`, `\Clarkson_Core\Object\base_term`, `\Clarkson_Core\Object\Clarkson_Term`
    * Users: `\Clarkson_Core\Object\user`, `\Clarkson_Core\Object\Clarkson_User`
- Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
- Adds `clarkson_term_types` and `clarkson_user_type` filters to overwrite class lookup.

Backward compatibility breaks:
- Removes deprecated features everywhere except for wordpress-objects/
- Removes loading of user roles instead of a user object.
- Removes deprecated construction of objects by id. Use ::get instead.
- Objects, term and user creation calls (such as ::get and ::get_one) now return null instead of throwing an error when no valid result is found.


This change also raises the psalm checks to level 2.

Fixes #184. Fixes #161. Fixes #142. Fixes #138. Fixes #133. Fixes #112. Fixes #110.