### PR TITLE
Fixes #88. Allows get_many to set a WP_Query variable.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
 * Adds `clarkson_term_types` and `clarkson_user_type` filters to overwrite class lookup.
 * Adds `Clarkson_Post_Type` object. `post_type` is also automatically added to the template context on archive pages.
+* `Clarkson_Object::get_many` can now set it a variable to it's \WP_Query.
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.

--- a/src/Object/Clarkson_Object.php
+++ b/src/Object/Clarkson_Object.php
@@ -92,19 +92,22 @@ class Clarkson_Object implements \JsonSerializable {
 	 * Get multiple posts, without pagination.
 	 *
 	 * @param array $args Post query arguments. {@link https://developer.wordpress.org/reference/classes/wp_query/#parameters}
+	 * @param mixed $post_query The $post_query is passed by reference and will be filled with the WP_Query that produced these results.
 	 *
 	 * @return Clarkson_Object[]
 	 *
 	 * @example
-	 * \Clarkson_Object::get_many( array( 'posts_per_page' => 5 ) );
+	 * \Clarkson_Object::get_many( array( 'posts_per_page' => 5 ), $post_query );
 	 */
-	public static function get_many( $args ) {
+	public static function get_many( $args, &$post_query = null ):array {
 		$args['post_type']     = static::$type;
 		$args['no_found_rows'] = true;
 		$args['fields']        = 'all';
 
-		$query = new \WP_Query( $args );
-		return Objects::get_instance()->get_objects( $query->posts );
+		$query      = new \WP_Query( $args );
+		$objects    = Objects::get_instance()->get_objects( $query->posts );
+		$post_query = $query;
+		return $objects;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #88. Allows get_many to set a WP_Query variable.