### PR TITLE
Rename namespace Clarkson_Core\Object to Clarkson_Core\WordPress_Object

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,10 +33,10 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Adds new `clarkson_core_template_context` filter.
 * Adds `object` as the first of `objects` to twig context.
 * There is now an object hierarchy:
-    * Objects: \Clarkson_Core\Object\$template, \Clarkson_Core\Object\$post_type, \Clarkson_Core\Object\base_object, \Clarkson_Core\Object\Clarkson_Object
-    * Terms: \Clarkson_Core\Object\$taxonomy, \Clarkson_Core\Object\base_term, \Clarkson_Core\Object\Clarkson_Term
-    * Users: \Clarkson_Core\Object\user, \Clarkson_Core\Object\Clarkson_User
-    * Post Types: \Clarkson_Core\Object\post_type_$post_type, \Clarkson_Core\Object\base_post_type, \Clarkson_Core\Object\Clarkson_Post_Type
+    * Objects: \Clarkson_Core\WordPress_Object\$template, \Clarkson_Core\WordPress_Object\$post_type, \Clarkson_Core\WordPress_Object\base_object, \Clarkson_Core\WordPress_Object\Clarkson_Object
+    * Terms: \Clarkson_Core\WordPress_Object\$taxonomy, \Clarkson_Core\WordPress_Object\base_term, \Clarkson_Core\WordPress_Object\Clarkson_Term
+    * Users: \Clarkson_Core\WordPress_Object\user, \Clarkson_Core\WordPress_Object\Clarkson_User
+    * Post Types: \Clarkson_Core\WordPress_Object\post_type_$post_type, \Clarkson_Core\WordPress_Object\base_post_type, \Clarkson_Core\WordPress_Object\Clarkson_Post_Type
     * Blocks: \Gutenberg\Blocks\$block_name, \Gutenberg\Blocks\base_block, Clarkson_Core\Gutenberg\Block_Type
 * Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
 * Adds `clarkson_term_types` and `clarkson_user_type` filters to overwrite class lookup.

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -7,10 +7,10 @@
 
 namespace Clarkson_Core;
 
-use Clarkson_Core\Object\Clarkson_Object;
-use Clarkson_Core\Object\Clarkson_Post_Type;
-use Clarkson_Core\Object\Clarkson_Term;
-use Clarkson_Core\Object\Clarkson_User;
+use Clarkson_Core\WordPress_Object\Clarkson_Object;
+use Clarkson_Core\WordPress_Object\Clarkson_Post_Type;
+use Clarkson_Core\WordPress_Object\Clarkson_Term;
+use Clarkson_Core\WordPress_Object\Clarkson_User;
 use DomainException;
 
 /**
@@ -18,7 +18,7 @@ use DomainException;
  * Objects.
  */
 class Objects {
-	const OBJECT_CLASS_NAMESPACE = '\\Clarkson_Core\\Object\\';
+	const OBJECT_CLASS_NAMESPACE = '\\Clarkson_Core\\WordPress_Object\\';
 	/**
 	 * Convert WP_Term object to a Clarkson Object.
 	 *

--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -5,7 +5,7 @@
  * @package CLARKSON\Objects
  */
 
-namespace Clarkson_Core\Object;
+namespace Clarkson_Core\WordPress_Object;
 
 use Clarkson_Core\Objects;
 

--- a/src/WordPress_Object/Clarkson_Post_Type.php
+++ b/src/WordPress_Object/Clarkson_Post_Type.php
@@ -5,7 +5,7 @@
  * @package CLARKSON\Objects
  */
 
-namespace Clarkson_Core\Object;
+namespace Clarkson_Core\WordPress_Object;
 
 use Clarkson_Core\Objects;
 

--- a/src/WordPress_Object/Clarkson_Term.php
+++ b/src/WordPress_Object/Clarkson_Term.php
@@ -5,7 +5,7 @@
  * @package CLARKSON\Objects
  */
 
-namespace Clarkson_Core\Object;
+namespace Clarkson_Core\WordPress_Object;
 
 /**
  * Object oriented wrapper for WP_Term objects.

--- a/src/WordPress_Object/Clarkson_User.php
+++ b/src/WordPress_Object/Clarkson_User.php
@@ -3,7 +3,7 @@
  * Clarkson User.
  */
 
-namespace Clarkson_Core\Object;
+namespace Clarkson_Core\WordPress_Object;
 
 use Clarkson_Core\Objects;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,9 @@
 
 // First we need to load the composer autoloader so we can use WP Mock.
 
-use Clarkson_Core\Object\Clarkson_Object;
-use Clarkson_Core\Object\Clarkson_Term;
-use Clarkson_Core\Object\Clarkson_User;
+use Clarkson_Core\WordPress_Object\Clarkson_Object;
+use Clarkson_Core\WordPress_Object\Clarkson_Term;
+use Clarkson_Core\WordPress_Object\Clarkson_User;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/custom_test_template.php
+++ b/tests/custom_test_template.php
@@ -3,4 +3,4 @@
 /**
  * This file is used to test cutom templated objects.
  */
-class custom_test_template extends \Clarkson_Core\Object\Clarkson_Object{}; //phpcs:ignore
+class custom_test_template extends \Clarkson_Core\WordPress_Object\Clarkson_Object{}; //phpcs:ignore

--- a/tests/lib/clarkson-core-objects.test.php
+++ b/tests/lib/clarkson-core-objects.test.php
@@ -1,8 +1,8 @@
 <?php
 
-use Clarkson_Core\Object\Clarkson_Object;
-use Clarkson_Core\Object\Clarkson_Term;
-use Clarkson_Core\Object\Clarkson_User;
+use Clarkson_Core\WordPress_Object\Clarkson_Object;
+use Clarkson_Core\WordPress_Object\Clarkson_Term;
+use Clarkson_Core\WordPress_Object\Clarkson_User;
 use Clarkson_Core\Objects;
 
 class ClarksonCoreObjectsTest extends \WP_Mock\Tools\TestCase {

--- a/tests/wordpress-objects/Clarkson_Object.test.php
+++ b/tests/wordpress-objects/Clarkson_Object.test.php
@@ -1,7 +1,7 @@
 <?php
 
-use Clarkson_Core\Object\Clarkson_Object;
-use Clarkson_Core\Object\Clarkson_Term;
+use Clarkson_Core\WordPress_Object\Clarkson_Object;
+use Clarkson_Core\WordPress_Object\Clarkson_Term;
 
 class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/wordpress-objects/Clarkson_User.test.php
+++ b/tests/wordpress-objects/Clarkson_User.test.php
@@ -1,6 +1,6 @@
 <?php
 
-use Clarkson_Core\Object\Clarkson_User;
+use Clarkson_Core\WordPress_Object\Clarkson_User;
 
 class ClarksonUserTest extends \WP_Mock\Tools\TestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;


### PR DESCRIPTION
Fixes this psalm error:
` 'object' is a soft reserved keyword as of PHP version 7.0 and a reserved keyword as of PHP version 7.2 and should not be used to name a class, interface or trait or as part of a namespace (T_NAMESPACE)`