### PR TITLE
Consistent getter API

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,7 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * The twig environment is now only created once per request.
 * `Clarkson_Object::get_many` can now set it a variable to it's \WP_Query.
 * Adds a filter `clarkson_core_{$post_type}_templates` to manipulate templates per post type.
+* Adds `::get_many`, `::get_one` and `::get` methods to `Clarkson_Term` and `Clarkson_User`.
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.

--- a/src/WordPress_Object/Clarkson_Term.php
+++ b/src/WordPress_Object/Clarkson_Term.php
@@ -7,6 +7,8 @@
 
 namespace Clarkson_Core\WordPress_Object;
 
+use Clarkson_Core\Objects;
+
 /**
  * Object oriented wrapper for WP_Term objects.
  */
@@ -72,6 +74,45 @@ class Clarkson_Term {
 			return null;
 		}
 		return \Clarkson_Core\Objects::get_instance()->get_term( $term );
+	}
+
+	/**
+	 * Alias of `get_by_id()`.
+	 */
+	public static function get( int $term_id ): ?Clarkson_Term {
+		return static::get_by_id( $term_id );
+	}
+
+	/**
+	 * Get multiple terms as Clarkson Objects.
+	 *
+	 * @param array $args Term query arguments. {@link https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/}
+	 * @param mixed $term_query The $term_query is passed by reference and will be filled with the WP_Term_Query that produced these results.
+	 *
+	 * @return Clarkson_Term[]
+	 *
+	 * @example
+	 * \Clarkson_Term::get_many( array( 'number' => 5 ), $term_query );
+	 */
+	public static function get_many( array $args, &$term_query = null ):array {
+		$args['taxonomy'] = static::$taxonomy;
+		$args['fields']   = 'all';
+
+		$query      = new \WP_Term_Query( $args );
+		$objects    = Objects::get_instance()->get_terms( $query->get_terms() );
+		$term_query = $query;
+		return $objects;
+	}
+
+	/**
+	 * Gets the first result from a `::get_many()` query.
+	 *
+	 * @param array $args Term query arguments. {@link https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/}
+	 */
+	public static function get_one( array $args = array() ):?Clarkson_Term {
+		$args['number'] = 1;
+		$one            = static::get_many( $args );
+		return array_shift( $one );
 	}
 
 	/**

--- a/src/WordPress_Object/Clarkson_User.php
+++ b/src/WordPress_Object/Clarkson_User.php
@@ -43,6 +43,38 @@ class Clarkson_User {
 	}
 
 	/**
+	 * Get multiple users as Clarkson users.
+	 *
+	 * @param array $args User query arguments. {@link https://developer.wordpress.org/reference/classes/wp_user_query/#parameters}
+	 * @param mixed $user_query The $user_query is passed by reference and will be filled with the WP_User_Query that produced these results.
+	 *
+	 * @return Clarkson_User[]
+	 *
+	 * @example
+	 * \Clarkson_User::get_many( array( 'role' => 'subscriber' ), $user_query );
+	 */
+	public static function get_many( array $args, &$user_query = null ):array {
+		$args['fields'] = 'all';
+
+		$query = new \WP_User_Query( $args );
+		$query->query();
+		$objects    = Objects::get_instance()->get_users( $query->get_results() );
+		$user_query = $query;
+		return $objects;
+	}
+
+	/**
+	 * Gets the first result from a `::get_many()` query.
+	 *
+	 * @param array $args User query arguments. {@link https://developer.wordpress.org/reference/classes/wp_user_query/#parameters}
+	 */
+	public static function get_one( array $args = array() ):?Clarkson_User {
+		$args['number'] = 1;
+		$one            = static::get_many( $args );
+		return array_shift( $one );
+	}
+
+	/**
 	 * Clarkson_User constructor.
 	 */
 	public function __construct( \WP_User $user ) {


### PR DESCRIPTION
This changeset adds `::get_many`, `::get_one` and `::get` methods to `Clarkson_Term` and `Clarkson_User`. This way we can have a standardised interface over all different WordPress object types.