### PR TITLE
Fix symlinked render call

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,10 +24,10 @@ jobs:
       run: |
         npm run doc
 
-    - name: Run NPM CI
-      uses: docker://uniplug/apigen:latest
+    - name: Generate PHP API docs
+      uses: docker://phpdoc/phpdoc:3
       with:
-        args: "apigen generate -d out/phpdoc -s src --access-levels public -o"
+        args: phpdoc run --title ClarksonCore --visibility public --sourcecode -d src -t out/phpdoc
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.vscode/
 composer.lock
 .phpunit.result.cache
+/.phpdoc

--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -11,9 +11,6 @@
  *
  * Text Domain: clarkson-core
  * Domain Path: /lang/
- *
- * @package CLARKSON\Main
- * @author Level Level
  */
 
 namespace Clarkson_Core;

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
 		],
 		"phpunit":[
 			"phpunit"
+		],
+		"doc":[
+			"docker run --rm -v $(pwd):/data phpdoc/phpdoc:3 run --title \"Clarkson Core\" --visibility public --sourcecode -d src -t out/phpdoc"
 		]
 	},
 	"require" : {

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Core Autoloader.
- *
- * @package CLARKSON\Lib
  */
 
 namespace Clarkson_Core;

--- a/src/Gutenberg/Block_Manager.php
+++ b/src/Gutenberg/Block_Manager.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Integrates Clarkson and Gutenberg to allow for twig rendering of blocks.
- * 
+ *
  * @since 0.4.0
  */
 

--- a/src/Gutenberg/Block_Manager.php
+++ b/src/Gutenberg/Block_Manager.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Integrates Clarkson and Gutenberg to allow for twig rendering of blocks.
- *
- * @package CLARKSON\Lib
+ * 
  * @since 0.4.0
  */
 

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Allows for extension of Gutenberg blocks and overwriting rendering functions.
- *
- * @package CLARKSON\Lib
+ * 
  * @since 0.4.0
  */
 

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Allows for extension of Gutenberg blocks and overwriting rendering functions.
- * 
+ *
  * @since 0.4.0
  */
 

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Core Objects.
- *
- * @package CLARKSON\Lib
  */
 
 namespace Clarkson_Core;

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Core Template Context.
- *
- * @package CLARKSON\Lib
  */
 
 namespace Clarkson_Core;

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -304,7 +304,7 @@ class Templates {
 			 *  return $context
 			 * } );
 			 */
-			$context  = apply_filters( 'clarkson_core_template_context', array(), $wp_query );
+			$context = apply_filters( 'clarkson_core_template_context', array(), $wp_query );
 			$this->render( $template, $context, true );
 		}
 

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -88,6 +88,8 @@ class Templates {
 	 * @return string
 	 */
 	public function render_twig( $path, $objects, $ignore_warning = false ) {
+		$path = realpath( $path );
+
 		// Twig arguments.
 		if ( ! $ignore_warning && $this->has_been_called ) {
 			user_error( 'Template rendering has already been called. If you are trying to render a partial, include the file from the parent template for performance reasons. If you have a specific reason to render multiple times, set ignore_warning to true.', E_USER_NOTICE );
@@ -305,7 +307,6 @@ class Templates {
 			 * } );
 			 */
 			$context  = apply_filters( 'clarkson_core_template_context', array(), $wp_query );
-			$template = realpath( $template );
 			$this->render( $template, $context, true );
 		}
 

--- a/src/Templates.php
+++ b/src/Templates.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Core Templates.
- *
- * @package CLARKSON\Lib
  */
 
 namespace Clarkson_Core;

--- a/src/Twig_Extension.php
+++ b/src/Twig_Extension.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Core Twig extension.
- *
- * @package CLARKSON\Lib
  */
 
 namespace Clarkson_Core;

--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Object.
- *
- * @package CLARKSON\Objects
  */
 
 namespace Clarkson_Core\WordPress_Object;

--- a/src/WordPress_Object/Clarkson_Post_Type.php
+++ b/src/WordPress_Object/Clarkson_Post_Type.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Post Type.
- *
- * @package CLARKSON\Objects
  */
 
 namespace Clarkson_Core\WordPress_Object;

--- a/src/WordPress_Object/Clarkson_Term.php
+++ b/src/WordPress_Object/Clarkson_Term.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Clarkson Term.
- *
- * @package CLARKSON\Objects
  */
 
 namespace Clarkson_Core\WordPress_Object;


### PR DESCRIPTION
If we do not do this, the caller might be referring to a symlinked file, while we are replacing our realpath directories.

Also improves API doc generation.