### PR TITLE
Fixes issue when calling render with a non-absolute path.

### DIFF
--- a/src/Templates.php
+++ b/src/Templates.php
@@ -86,7 +86,10 @@ class Templates {
 	 * @return string
 	 */
 	public function render_twig( $path, $objects, $ignore_warning = false ) {
-		$path = realpath( $path );
+		$clean_path = realpath( $path );
+		if ( $clean_path ) {
+			$path = $clean_path;
+		}
 
 		// Twig arguments.
 		if ( ! $ignore_warning && $this->has_been_called ) {


### PR DESCRIPTION
If this is an absolute path, we want the realpath. If it is not we take it as it was given to us.