### PR TITLE
Correctly loads templates based on possibilities in WordPress.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,9 +33,10 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Adds new `clarkson_core_template_context` filter.
 * Adds `object` as the first of `objects` to twig context.
 * There is now an object hierarchy:
-    * Objects: \Clarkson_Core\WordPress_Object\$template, \Clarkson_Core\WordPress_Object\$post_type, \Clarkson_Core\WordPress_Object\base_object, \Clarkson_Core\WordPress_Object\Clarkson_Object
+    * Objects: \Clarkson_Core\WordPress_Object\$post_type, \Clarkson_Core\WordPress_Object\base_object, \Clarkson_Core\WordPress_Object\Clarkson_Object
     * Terms: \Clarkson_Core\WordPress_Object\$taxonomy, \Clarkson_Core\WordPress_Object\base_term, \Clarkson_Core\WordPress_Object\Clarkson_Term
     * Users: \Clarkson_Core\WordPress_Object\user, \Clarkson_Core\WordPress_Object\Clarkson_User
+    * Templates: \Clarkson_Core\WordPress_Object\$template, \Clarkson_Core\WordPress_Object\base_template, \Clarkson_Core\WordPress_Object\Clarkson_Template,   
     * Post Types: \Clarkson_Core\WordPress_Object\post_type_$post_type, \Clarkson_Core\WordPress_Object\base_post_type, \Clarkson_Core\WordPress_Object\Clarkson_Post_Type
     * Blocks: \Gutenberg\Blocks\$block_name, \Gutenberg\Blocks\base_block, Clarkson_Core\Gutenberg\Block_Type
 * Adds `get_terms()` method to mimic `get_objects` and `get_users` on Object factory.
@@ -48,7 +49,6 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 * Adds `get_roles()` method (returns role name as string) to `Clarkson_User`.
 * Adds `get_role_objects()` method (returns `Clarkson_Role`) to `Clarkson_User`.
 * The `get_children()` and `get_attachments()` methods on the `Clarkson_Object` now accepts a Post arguments parameter.
-
 
 Backward incompatible changes:
 * Removes compatibility for WordPress < 4.7.
@@ -64,6 +64,7 @@ Backward incompatible changes:
 * Updates required PHP version to 7.2.
 * Removes `get_role()` method from `Clarkson_User` because a user can have multiple roles. Replaced with `get_roles()` method, which returns an array of role names.
 * The `get_children()` and `get_attachments()` methods on the `Clarkson_Object` now return `Clarkson_Object[]` instead of `WP_Post[]`.
+* Template objects are now standalone objects (`Clarkson_Template`), instead of extending `Clarkson_Object`.
 
 = 0.4.2 - August 19, 2019 =
 

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -364,7 +364,7 @@ class Objects {
 	}
 
 	/**
-	 * Get an array of posts converted to their corresponding WordPress object class.
+	 * Get an array of posts converted to their corresponding WordPress template class.
 	 *
 	 * @param \WP_Post[] $posts Posts.
 	 *

--- a/src/Objects.php
+++ b/src/Objects.php
@@ -8,6 +8,7 @@ namespace Clarkson_Core;
 use Clarkson_Core\WordPress_Object\Clarkson_Object;
 use Clarkson_Core\WordPress_Object\Clarkson_Post_Type;
 use Clarkson_Core\WordPress_Object\Clarkson_Role;
+use Clarkson_Core\WordPress_Object\Clarkson_Template;
 use Clarkson_Core\WordPress_Object\Clarkson_Term;
 use Clarkson_Core\WordPress_Object\Clarkson_User;
 use DomainException;
@@ -178,12 +179,6 @@ class Objects {
 			array_unshift( $types, self::OBJECT_CLASS_NAMESPACE . $type );
 		}
 
-		$page_template_slug = $cc->autoloader->get_template_filename( $post->ID );
-		$page_template_slug = $cc->autoloader->sanitize_object_name( $page_template_slug );
-		if ( ! empty( $page_template_slug ) ) {
-			array_unshift( $types, self::OBJECT_CLASS_NAMESPACE . $page_template_slug );
-		}
-
 		$class_to_load = null;
 		foreach ( $types as $type ) {
 			if ( class_exists( $type ) ) {
@@ -318,6 +313,73 @@ class Objects {
 		return new Clarkson_Role( $role );
 	}
 
+	public function get_template( \WP_Post $post ): Clarkson_Template {
+		$template = get_page_template_slug( $post );
+		$template = pathinfo( (string) $template, PATHINFO_FILENAME );
+
+		$template = Clarkson_Core::get_instance()->autoloader->sanitize_object_name( $template );
+		if ( empty( $template ) ) {
+			$template = 'template_default';
+		}
+
+		$class_name = self::OBJECT_CLASS_NAMESPACE . $template;
+		/**
+		 * Allows the theme to overwrite class that is going to be used to create a template object.
+		 *
+		 * @hook clarkson_template_class
+		 * @since 1.0.0
+		 * @param {null|string} $type Sanitized class name.
+		 * @param {WP_Post} $post The WordPress post to load a template for.
+		 * @return {null|string} Class name of template to be created.
+		 *
+		 * @example
+		 * // load a different class instead of what Clarkson Core calculates.
+		 * add_filter( 'clarkson_template_class', function( $class, $post ) {
+		 *  if ( $post->ID === 15 ){
+		 *      $class = self::OBJECT_CLASS_NAMESPACE . 'custom_template_class';
+		 *  }
+		 *  return $class;
+		 * }, 10, 2 );
+		 */
+		$class_name = apply_filters( 'clarkson_template_class', $class_name, $post );
+		if ( class_exists( $class_name ) ) {
+			$object = new $class_name( $post );
+			if ( $object instanceof Clarkson_Template ) {
+				return $object;
+			}
+		}
+
+		/**
+		 * @psalm-var string
+		 */
+		$class_name = self::OBJECT_CLASS_NAMESPACE . 'base_template';
+		if ( class_exists( $class_name ) ) {
+			$object = new $class_name( $post );
+			if ( $object instanceof Clarkson_Template ) {
+				return $object;
+			}
+		}
+
+		return new Clarkson_Template( $post );
+	}
+
+	/**
+	 * Get an array of posts converted to their corresponding WordPress object class.
+	 *
+	 * @param \WP_Post[] $posts Posts.
+	 *
+	 * @return Clarkson_Template[] $objects Array of post templates.
+	 */
+	public function get_templates( array $posts ): array {
+		$objects = array();
+
+		foreach ( $posts as $post ) {
+			$objects[] = $this->get_template( $post );
+		}
+
+		return $objects;
+	}
+
 	/**
 	 * Get an array of post types converted from their corresponding WordPress post type class.
 	 *
@@ -350,7 +412,7 @@ class Objects {
 		 * @hook clarkson_post_type_class
 		 * @since 1.0.0
 		 * @param {null|string} $type Sanitized class name.
-		 * @param {WP_Post_Type} $post_type Sanitized class name.
+		 * @param {WP_Post_Type} $post_type The original post type object.
 		 * @return {null|string} Class name of post_type to be created.
 		 *
 		 * @example

--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -112,10 +112,8 @@ class Clarkson_Object implements \JsonSerializable {
 	 * Gets the first result from a `::get_many()` query.
 	 *
 	 * @param array $args Post query arguments. {@link https://developer.wordpress.org/reference/classes/wp_query/#parameters}
-	 *
-	 * @return Clarkson_Object|null
 	 */
-	public static function get_one( $args = array() ) {
+	public static function get_one( $args = array() ):?Clarkson_Object {
 		$args['posts_per_page'] = 1;
 		$one                    = static::get_many( $args );
 		return array_shift( $one );
@@ -128,6 +126,10 @@ class Clarkson_Object implements \JsonSerializable {
 	 */
 	public function get_id() {
 		return $this->_post->ID;
+	}
+
+	public function get_template():Clarkson_Template {
+		return Objects::get_instance()->get_template( $this->_post );
 	}
 
 	/**

--- a/src/WordPress_Object/Clarkson_Template.php
+++ b/src/WordPress_Object/Clarkson_Template.php
@@ -1,0 +1,95 @@
+<?php
+
+
+/**
+ * Clarkson Template.
+ */
+
+namespace Clarkson_Core\WordPress_Object;
+
+use Clarkson_Core\Objects;
+
+class Clarkson_Template {
+	/**
+	 * The string here is the template name used by `::get_many()`.
+	 *
+	 * @var string
+	 */
+	public static $type = '';
+
+	/**
+	 * @var \WP_Post
+	 */
+	protected $_post;
+
+	/**
+	 * @var Clarkson_Object|null
+	 */
+	private $_object;
+
+	public function __construct( \WP_Post $post ) {
+		$this->_post = $post;
+	}
+
+	public static function get( int $id ):?Clarkson_Template {
+		$post = get_post( $id );
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+		return Objects::get_instance()->get_template( $post );
+	}
+
+	/**
+	 * Get multiple templates, without pagination.
+	 *
+	 * @param array $args Post query arguments. {@link https://developer.wordpress.org/reference/classes/wp_query/#parameters}
+	 * @param mixed $post_query The $post_query is passed by reference and will be filled with the WP_Query that produced these results.
+	 *
+	 * @return Clarkson_Template[]
+	 *
+	 * @example
+	 * \Clarkson_Template::get_many( array( 'posts_per_page' => 5 ), $post_query );
+	 */
+	public static function get_many( array $args, &$post_query = null ):array {
+		$args                 = wp_parse_args(
+			$args,
+			array(
+				'post_type'  => 'any',
+				'meta_query' => array(),
+			)
+		);
+		$args['meta_query'][] = array(
+			'key'   => '_wp_page_template',
+			'value' => static::$type,
+		);
+
+		$args['no_found_rows'] = true;
+		$args['fields']        = 'all';
+
+		$query      = new \WP_Query( $args );
+		$objects    = Objects::get_instance()->get_templates( $query->posts );
+		$post_query = $query;
+		return $objects;
+	}
+
+	/**
+	 * Gets the first result from a `::get_many()` query.
+	 *
+	 * @param array $args Post query arguments. {@link https://developer.wordpress.org/reference/classes/wp_query/#parameters}
+	 */
+	public static function get_one( $args = array() ): ?Clarkson_Template {
+		$args['posts_per_page'] = 1;
+		$one                    = static::get_many( $args );
+		return array_shift( $one );
+	}
+
+	/**
+	 * Get the Clarkson object for this template.
+	 */
+	public function get_object():Clarkson_Object {
+		if ( empty( $this->_object ) ) {
+			$this->_object = Objects::get_instance()->get_object( $this->_post );
+		}
+		return $this->_object;
+	}
+}


### PR DESCRIPTION
Previously a template was an extension of a regular Clarkson_Object. This meant that a template could only extend one 'post_type'. For example, a `template_contact` could only extend a `page`.

However, in WordPress a template can be applicable to any number of post types. Basically, a `template_contact` could be set on a `page`, but also on a `custom_post_type`. In the old method, we would have to choose which object to extend, and maintain the other object to keep the same interface methods available.

In the new method the Clarkson Object gets loaded instead of a Clarkson_Template object. On the Clarkson_Object you can then ask `get_template()` which retrieves the template. Also, this allows object creation of standalone template objects, and adds `get_one` and `get_many` methods.

The `get_one` is usefull if you need a single instance of a template such as a contact page. You simple use `$contact_page = template_contact::get_one(); return $contact_page->get_required_fields() ?? array();`