### PR TITLE
Attempts to fix API docs generation.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Generate PHP API docs
       uses: docker://phpdoc/phpdoc:3
       with:
-        args: phpdoc run
+        args: run
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - test-docs
 
 jobs:
   build:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Generate PHP API docs
       uses: docker://phpdoc/phpdoc:3
       with:
-        args: run
+        args: run --title ClarksonCore --visibility public --sourcecode -d src -t out/phpdoc
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Generate PHP API docs
       uses: docker://phpdoc/phpdoc:3
       with:
-        args: phpdoc run -d src -t out/phpdoc
+        args: phpdoc run
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - test-docs
 
 jobs:
   build:
@@ -27,7 +28,7 @@ jobs:
     - name: Generate PHP API docs
       uses: docker://phpdoc/phpdoc:3
       with:
-        args: phpdoc run --title ClarksonCore --visibility public --sourcecode -d src -t out/phpdoc
+        args: phpdoc run -d src -t out/phpdoc
 
     - name: Publish pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Install PHP
-      uses: shivammathur/setup-php@1.3.7
+      uses: shivammathur/setup-php@2.7.0
       with:
         php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
API doc generation is failing in https://github.com/level-level/Clarkson-Core/runs/1472578847, but does not fail locally. This branch is to debug the situation in a real GH Actions environment.