### PR TITLE
Creates new filter to add variables to block render context.

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:  Clarkson Core
- * Version:      1.0.0
+ * Version:      1.1.0
  * Plugin URI:   http://wp-clarkson.com/core
  * Description:  A mu-plugin to write Object-Oriented code in combination with the Twig templating engine while keeping the WordPress Way of working in mind.
  * Author:       Level Level

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: level level, jmslbam
 Tags: twig, templating, template engine, templates, oop, wordpress objects
 Requires at least: 4.7
 Tested up to: 4.9.4
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPL v2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ Yes, at Level Level we use it for all of our new projects. It's already running 
 
 
 == Changelog ==
+
+= 1.1.0 =
+
+* Adds a new `clarkson_core_block_context_{$name}` hook to modify variables available in the twig render function of a block.
 
 = 1.0.0 =
 

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -83,13 +83,37 @@ class Block_Type extends \WP_Block_Type {
 		if ( file_exists( $this->get_twig_template_path() ) ) {
 			$cc_template              = Templates::get_instance();
 			$this->content_attributes = $attributes;
+
+			$context_args = array(
+				'data'    => $attributes,
+				'content' => $content,
+				'block'   => $this,
+			);
+
+			/**
+			 * Allows theme to overwrite the the variables available when rendering a specific block.
+			 *
+			 * @hook clarkson_core_block_context_{$name}
+			 * @since 1.1.0
+			 * @param {string} $context Variables available in the twig render function.
+			 * @param {Block_Type} $block Block that triggered this filter.
+			 * @return {string} Variables available in the twig render function.
+			 *
+			 * @example
+			 * // Add an Assets object to a blocks twig context variables.
+			 * add_filter(
+			 *  'clarkson_core_block_context_org/events',
+			 *  function( $context, $block ) {
+			 *      $context['assets'] = new Assets();
+			 *      return $context;
+			 *  }, 10, 2
+			 * );
+			 */
+			$context_args = apply_filters( 'clarkson_core_block_context_' . $this->name, $context_args, $this );
+
 			return (string) $cc_template->render_twig(
 				$this->get_twig_template_path(),
-				array(
-					'data'    => $attributes,
-					'content' => $content,
-					'block'   => $this,
-				),
+				$context_args,
 				true
 			);
 		}


### PR DESCRIPTION
New filter `clarkson_core_block_context_{$name}` runs before twig rendering a block.

This allows developers to add block-specific context without using `clarkson_context_args`, which would add it to 'all' blocks.