### PR TITLE
Error after activate plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,7 @@
 	"autoload": {
 		"psr-4": {
 			"Clarkson_Core\\": "src/"
-		},
-		"files": [
-			"clarkson-core.php"
-		]
+		}
 	},
 	"scripts": {
 		"fix" : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
https://github.com/level-level/Clarkson-Core/issues/220

## Description
After activating the plugin it shows an error that the class is already declared and it is because they forgot to delete the line in the composer.json file where the clarkson-core.php file is called again.

Fatal error: Cannot declare class Clarkson_Core\Clarkson_Core, because the name is already in use in /plugins/clarkson-core/clarkson-core.php on line 23

