### PR TITLE
Fix return type of Clarkson_Object->get_thumbnail_id()

### DIFF
--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -198,10 +198,10 @@ class Clarkson_Object implements \JsonSerializable {
 	/**
 	 * Get the thumbnail id by post id.
 	 *
-	 * @return string|int The ID of the post, or an empty string on failure.
+	 * @return int The ID of the post, 0 on failure.
 	 */
 	public function get_thumbnail_id() {
-		return get_post_thumbnail_id( $this->get_id() );
+		return (int) get_post_thumbnail_id( $this->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
None

## Description
<!--- Describe your changes in detail -->
Documentation was wrong, as the return type could be int|false. Not int|string as was documented
This fix casts it to an integer, and only makes the return type int.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.