### PR TITLE
Adds page for posts to template context

### DIFF
--- a/docs/getting-started/templating.rst
+++ b/docs/getting-started/templating.rst
@@ -156,7 +156,7 @@ Clarkson Core will have some :doc:`clarkson-objects` available in a template by 
 
     // home (home.twig)
     [
-        'posts_page' => "An object representing the selected posts page"
+        'posts_page' => "An object representing the selected posts page",
         'objects' => "All results of the query, maybe limited by posts_per_page.",
     ]
 

--- a/docs/getting-started/templating.rst
+++ b/docs/getting-started/templating.rst
@@ -152,6 +152,14 @@ Clarkson Core will have some :doc:`clarkson-objects` available in a template by 
         'found_posts' => "Number of posts matching the query"
     ]
 
+.. code-block:: php
+
+    // home (home.twig)
+    [
+        'posts_page' => "An object representing the selected posts page"
+        'objects' => "All results of the query, maybe limited by posts_per_page.",
+    ]
+
 
 .. note::
 

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -16,6 +16,7 @@ class Template_Context {
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_search_count' ), 5, 2 );
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_posts' ), 5, 2 );
 		add_filter( 'clarkson_core_template_context', array( $this, 'add_post_type' ), 5, 2 );
+		add_filter( 'clarkson_core_template_context', array( $this, 'add_posts_page' ), 5 );
 	}
 
 	/**
@@ -75,6 +76,26 @@ class Template_Context {
 				$context['post_type'] = Objects::get_instance()->get_post_type( $queried_object );
 			}
 		}
+		return $context;
+	}
+
+	/**
+	 * Adds posts page overview as Clarkson Object if current page is home
+	 */
+	public function add_posts_page( array $context ):array {
+		if ( ! is_home() ) {
+			return $context;
+		}
+
+		$page_for_posts = get_option( 'page_for_posts' );
+
+		if ( empty( $page_for_posts ) ) {
+			return $context;
+		}
+
+		$post                  = get_post( get_option( 'page_for_posts' ) );
+		$context['posts_page'] = Objects::get_instance()->get_object( $post );
+
 		return $context;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
n/a

## Description
<!--- Describe your changes in detail -->
Makes it possible to do for example `posts_page.get_title()`  in the home.twig

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.