### PR TITLE
Fix issue where post_type was not added to context when filtering.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,10 @@
 		"10up/wp_mock": "^0.4.2",
 		"wp-coding-standards/wpcs": "^2.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/Template_Context.php
+++ b/src/Template_Context.php
@@ -5,6 +5,8 @@
 
 namespace Clarkson_Core;
 
+use Clarkson_Core\WordPress_Object\Clarkson_Post_Type;
+
 class Template_Context {
 
 	/**
@@ -70,11 +72,22 @@ class Template_Context {
 	}
 
 	public function add_post_type( array $context, \WP_Query $wp_query ):array {
-		if ( $wp_query->is_post_type_archive ) {
-			$queried_object = get_queried_object();
-			if ( $queried_object instanceof \WP_Post_Type ) {
-				$context['post_type'] = Objects::get_instance()->get_post_type( $queried_object );
-			}
+		if ( ! $wp_query->is_post_type_archive ) {
+			return $context;
+		}
+
+		$post_type      = null;
+		$queried_object = get_queried_object();
+		if ( $queried_object instanceof \WP_Post_Type ) {
+			$post_type = Objects::get_instance()->get_post_type( $queried_object );
+		} elseif ( isset( $wp_query->query['post_type'] ) && is_string( $wp_query->query['post_type'] ) ) {
+			$post_type = Clarkson_Post_Type::get( $wp_query->query['post_type'] );
+		} elseif ( isset( $wp_query->query_vars['post_type'] ) && is_string( $wp_query->query_vars['post_type'] ) ) {
+			$post_type = Clarkson_Post_Type::get( $wp_query->query_vars['post_type'] );
+		}
+
+		if ( $post_type ) {
+			$context['post_type'] = $post_type;
 		}
 		return $context;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://github.com/level-level/Clarkson-Core/issues/239

## Description
<!--- Describe your changes in detail -->
Fixes issue where the post_type was not always added to the twig template context on post archive pages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
In the podcast platform project, by filtering on the archive page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.