### PR TITLE
make wakeup functions public

### DIFF
--- a/clarkson-core.php
+++ b/clarkson-core.php
@@ -123,7 +123,7 @@ class Clarkson_Core {
 	/**
 	 * Wakeup.
 	 */
-	private function __wakeup() {
+	public function __wakeup() {
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,10 @@
 		"vimeo/psalm": "^3.4",
 		"10up/wp_mock": "^0.4.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/lib/clarkson-core-objects.php
+++ b/lib/clarkson-core-objects.php
@@ -274,7 +274,7 @@ class Clarkson_Core_Objects {
 	/**
 	 * Wakeup.
 	 */
-	private function __wakeup() {
+	public function __wakeup() {
 	}
 
 }

--- a/lib/clarkson-core-templates.php
+++ b/lib/clarkson-core-templates.php
@@ -721,7 +721,7 @@ class Clarkson_Core_Templates {
 	/**
 	 * Wakeup.
 	 */
-	private function __wakeup() {
+	public function __wakeup() {
 	}
 
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	bootstrap="tests/bootstrap.php"
+	convertDeprecationsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="Clarkson Core">

--- a/tests/wordpress-objects/Clarkson_Object.test.php
+++ b/tests/wordpress-objects/Clarkson_Object.test.php
@@ -23,7 +23,7 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 	}
 
 	public function test_can_construct_an_object_with_id() {
-		$this->expectException( '\PHPUnit\Framework\Error\Deprecated' );
+		$this->expectDeprecation();
 		\WP_Mock::userFunction( 'get_post' )->with( self::POST_ID )->andReturn( Mockery::mock( '\WP_Post' ) );
 		$object = new \Clarkson_Object( self::POST_ID );
 	}

--- a/tests/wordpress-objects/Clarkson_Object.test.php
+++ b/tests/wordpress-objects/Clarkson_Object.test.php
@@ -24,6 +24,7 @@ class ClarksonObjectTest extends \WP_Mock\Tools\TestCase {
 
 	public function test_can_construct_an_object_with_id() {
 		$this->expectException( '\PHPUnit\Framework\Error\Deprecated' );
+		\WP_Mock::userFunction( 'get_post' )->with( self::POST_ID )->andReturn( Mockery::mock( '\WP_Post' ) );
 		$object = new \Clarkson_Object( self::POST_ID );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://app.asana.com/0/1158427227176969/1202781815171104/f
## Description
<!--- Describe your changes in detail -->
Prepare clarkson 0.4 for php 8.
Fix the following warnings by making the wakeup functions public
![Screenshot 2022-08-15 at 13 04 17](https://user-images.githubusercontent.com/67947342/184624543-053dfcc2-80e2-4eb3-b186-f5e763db8132.png)

Also fixed a failing phpunit test:
- Use a mock get_post function, because get_post was not defined.
- Add convertDeprecationsToExceptions="true" because the test expects an exception of type deprecation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on local bi-de and bi-nl environment by replacing the clarkson version there with this branch. I also switched back and forth from php 7.3 to 8.0 to check backwards compatibility
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.