### PR TITLE
Allow Clarkson 0.4.x to be installed with php8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	"require" : {
 		"twig/twig":"^1.2",
 		"twig/extensions":"^1.3",
-		"php":"^7.1"
+		"php":"^7.1|^8.0"
 	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clarkson 0.4.x is capable of handling php8.x sites, but the composer file disallowed it. This broadens the install targets to allow php8 platforms to install clarkson-core 0.4.x

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.