### PR TITLE
Pass third, missing, argument to original callback in `clarkson_render_callback` when rendering original callback

### DIFF
--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -118,7 +118,7 @@ class Block_Type extends \WP_Block_Type {
 			);
 		}
 		if ( is_callable( $this->original_render_callback ) ) {
-			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $block );
+			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $this );
 		}
 		return $content;
 	}

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -118,7 +118,7 @@ class Block_Type extends \WP_Block_Type {
 			);
 		}
 		if ( is_callable( $this->original_render_callback ) ) {
-			return (string) call_user_func( $this->original_render_callback, $attributes, $content );
+			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $block );
 		}
 		return $content;
 	}


### PR DESCRIPTION
## Description
As `render_block_core_widget_group` of the Widget Group block needs 3 argments and not just 2. See line in Core  https://github.com/WordPress/wordpress-develop/blob/2beefda2c0448d6dab80d7e7b723058642e57b08/src/wp-includes/blocks/widget-group.php#L17


## How Has This Been Tested?
Latest Clarkson Core with Latest WP.
Enable debugging.
Add Widget Group to your sidebar and see Error.

## Error notices
```
Uncaught ArgumentCountError: Too few arguments to function Clarkson_Core\Gutenberg\Block_Type::clarkson_render_callback(), 2 passed and exactly 3 expected in /Users/xyz/local-sites/rc/app/public/wp-content/vendor/level-level/clarkson-core/src/Gutenberg/Block_Type.php:85 Stack trace: #0 [internal function]: Clarkson_Core\Gutenberg\Block_Type->clarkson_render_callback(Array, '\n<div class="wp...')
#1 /Users/xyz/local-sites/rc/app/public/wp-content/vendor/level-level/clarkson-core/src/Gutenberg/Block_Type.php(124): call_user_func(Array, Array, '\n<div class="wp...')
#2 /Users/jmslbam/local-sites/rc/app/public/wp-includes/class-wp-block.php(258): Clarkson_Core\Gutenberg\Block_Type->clarkson_render_callback(Array, '\n<div class="wp...', Object(WP_Block))
#3 /Users/xyz/local-sites/rc/app/public/wp-includes/class-wp-block.php(244): WP_Block->render()
#4 /Users/xyz/local-sites/rc/app/public/wp-includes/blocks.php(1072): WP_Block->render() #5 /Users/xyz/local-sites/rc/app/public/wp-includes/blocks.php(1110):
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.