### PR TITLE
pass WP_Block to render callback if available

### DIFF
--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -77,7 +77,7 @@ class Block_Type extends \WP_Block_Type {
 	 * exists it falls back to the original render callback.
 	 * @param array  $attributes Block attributes.
 	 * @param string $content    Block content.
-	 * @param \WP_Block|null $block
+	 * @param \WP_Block|null $block WP Block object
 	 * @return string Rendered block type output.
 	 */
 	public function clarkson_render_callback( $attributes, $content, $block = null ) {

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -77,9 +77,10 @@ class Block_Type extends \WP_Block_Type {
 	 * exists it falls back to the original render callback.
 	 * @param array  $attributes Block attributes.
 	 * @param string $content    Block content.
+	 * @param \WP_Block|null $block
 	 * @return string Rendered block type output.
 	 */
-	public function clarkson_render_callback( $attributes, $content ) {
+	public function clarkson_render_callback( $attributes, $content, $block = null ) {
 		if ( file_exists( $this->get_twig_template_path() ) ) {
 			$cc_template              = Templates::get_instance();
 			$this->content_attributes = $attributes;
@@ -118,7 +119,7 @@ class Block_Type extends \WP_Block_Type {
 			);
 		}
 		if ( is_callable( $this->original_render_callback ) ) {
-			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $this );
+			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $block );
 		}
 		return $content;
 	}


### PR DESCRIPTION
Some WordPress blocks expect a 3rd block render parameter with the WP_Block object. This was not passed. Since WP 4 this breaks.

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.