### PR TITLE
Fix jsonserialize function return type deprication notice in php 8.1+

### DIFF
--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -626,6 +626,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 *
 	 * We can't just return $this->_post, because these values will only return raw unfiltered data.
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize(): mixed {
 		$data              = array();
 		$data['id']        = $this->get_id();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://level-level.slack.com/archives/C02RENN0T/p1700146322403449
https://app.asana.com/0/1194139319537345/1205063740343242/f

## Description
<!--- Describe your changes in detail -->
Fixes php 8.1 and php 8.2 deprication notice for:

```
Deprecated: Return type of Clarkson_Core\WordPress_Object\Clarkson_Object::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Volumes/data/projects/twtg/wp-content/vendor/level-level/clarkson-core/src/WordPress_Object/Clarkson_Object.php on line 630
```

This notice has been temporarily fixed by adding this `#[\ReturnTypeWillChange]` code. We can remove this and make it compatible once we won't support php lower than 8.1 anymore with Clarkson Core.

PHP 8.2 is needed because one of our projects is hosted externally, and that is set up using php 8.2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've made this change in for the twtg project, and the notice dissapeared.

## Screenshots (if appropriate):
<img width="1318" alt="image" src="https://github.com/level-level/Clarkson-Core/assets/50165380/11403bf3-8da9-4e4e-a0e2-9a2fdcc54dd9">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.