### PR TITLE
Revert #263, fixes jsonSerialize fatal error on php 7.4 or lower

### DIFF
--- a/src/WordPress_Object/Clarkson_Object.php
+++ b/src/WordPress_Object/Clarkson_Object.php
@@ -627,7 +627,7 @@ class Clarkson_Object implements \JsonSerializable {
 	 * We can't just return $this->_post, because these values will only return raw unfiltered data.
 	 */
 	#[\ReturnTypeWillChange]
-	public function jsonSerialize(): mixed {
+	public function jsonSerialize() {
 		$data              = array();
 		$data['id']        = $this->get_id();
 		$data['link']      = $this->get_permalink();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://level-level.slack.com/archives/C02RENN0T/p1700146322403449
https://app.asana.com/0/1194139319537345/1205063740343242/f

## Description
<!--- Describe your changes in detail -->
Reverts PR #263 .
This is needed because now already changing the return type would cause a fatal in PHP 7.4 or lower.
Instead, PR #265 has been created to bypass the deprication notice in PHP 8.1+, till Clarkson Core will not support PHP versions below 8.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I picked a project running php 7.4.
And updated clarkson core in this project.
Then i added the following line to functions.php: `echo json_encode( post::get(1) );`. This breaks with the error shown in screenshot.
Then I removed the mixed return type from the jsonSerialize function.
The error is now gone.

## Screenshots (if appropriate):
<img width="709" alt="image" src="https://github.com/level-level/Clarkson-Core/assets/50165380/e3b92f6e-da62-4219-8552-35643db8cbd0">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.