### PR TITLE
WP 6.4 bugfix, add extra args to callback

### DIFF
--- a/lib/clarkson-core-gutenberg-block-type.php
+++ b/lib/clarkson-core-gutenberg-block-type.php
@@ -76,7 +76,7 @@ class Clarkson_Core_Gutenberg_Block_Type extends \WP_Block_Type {
 	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function clarkson_render_callback( $attributes, $content ) {
+	public function clarkson_render_callback( $attributes, $content, $block = null, $post_id = 0 ) {
 		if ( file_exists( $this->get_twig_template_path() ) ) {
 			$cc_template              = Clarkson_Core_Templates::get_instance();
 			$this->content_attributes = $attributes;
@@ -91,7 +91,7 @@ class Clarkson_Core_Gutenberg_Block_Type extends \WP_Block_Type {
 			);
 		}
 		if ( is_callable( $this->original_render_callback ) ) {
-			return (string) call_user_func( $this->original_render_callback, $attributes, $content );
+			return (string) call_user_func( $this->original_render_callback, $attributes, $content, $block, $post_id );
 		}
 		return $content;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
#260 

Refresh of #261 

## Description
Applies the same fix of https://github.com/level-level/Clarkson-Core/pull/260 in the 0.4 lts version.
And then also the updated fix from Christiaan in https://github.com/level-level/Clarkson-Core/pull/262.

Includes extra `$post_id` parameter to support WordPress 6.4+

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.