### PR TITLE
fix clarkson term taxonomy typing

### DIFF
--- a/wordpress-objects/Clarkson_Term.php
+++ b/wordpress-objects/Clarkson_Term.php
@@ -21,7 +21,7 @@ class Clarkson_Term {
 	/**
 	 * Clarkson_Term provides extra functions to retrieve term and taxonomy data.
 	 *
-	 * @var null
+	 * @var null|string
 	 */
 	protected static $taxonomy = null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->

## Description
<!--- Describe your changes in detail -->
Fixing the typing of taxonomy, now can hold strings aswel.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.