### PR TITLE
Only replace original render callback if not set

### DIFF
--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -23,7 +23,9 @@ class Block_Type extends \WP_Block_Type {
 	 */
 	public function __construct( $block_type, $args = array() ) {
 		parent::__construct( $block_type, $args );
-		$this->original_render_callback = $this->render_callback;
+		if ( empty( $this->original_render_callback ) ) {
+			$this->original_render_callback = $this->render_callback;
+		}
 		$this->render_callback          = array( $this, 'clarkson_render_callback' );
 	}
 

--- a/src/Gutenberg/Block_Type.php
+++ b/src/Gutenberg/Block_Type.php
@@ -26,7 +26,7 @@ class Block_Type extends \WP_Block_Type {
 		if ( empty( $this->original_render_callback ) ) {
 			$this->original_render_callback = $this->render_callback;
 		}
-		$this->render_callback          = array( $this, 'clarkson_render_callback' );
+		$this->render_callback = array( $this, 'clarkson_render_callback' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://app.asana.com/0/1206316631984075/1207645749086440/f

## Description
<!--- Describe your changes in detail -->
parse_blocks can crash beacuse of an infinite loop. 
Somehow for the image block the constructor can be called twice, resulting in the original render callback beeing the same as the render callback.
Because they became the same, the following call to fallback to the original render callback if no custom callback is available, will then cause an infinite loop (because render callback is calling the same render callback,etc).

This solution aims to solve this by only allowing the original render callback to be set once.
It's the original, so that should always be allright.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
In a project, by running parse_blocks with an image block in the content present.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.