### PR TITLE
Don't check if object is an Clarkson_Object

### DIFF
--- a/src/Objects.php
+++ b/src/Objects.php
@@ -167,7 +167,7 @@ class Objects {
 	 *
 	 * @return Clarkson_Object Clarkson Post object.
 	 */
-	public function get_object( \WP_Post $post ): Clarkson_Object {
+	public function get_object( \WP_Post $post ): object {
 		$cc = Clarkson_Core::get_instance();
 
 		$types = array(
@@ -235,10 +235,11 @@ class Objects {
 		 * } );
 		 */
 		$object_creation_callback = apply_filters( 'clarkson_core_create_object_callback', false, $class_to_load, $post->ID );
+
 		if ( is_callable( $object_creation_callback ) ) {
-			$clarkson_object = call_user_func_array( $object_creation_callback, array( $post->ID ) );
-			if ( $clarkson_object instanceof Clarkson_Object ) {
-				return $clarkson_object;
+			$object = call_user_func_array( $object_creation_callback, array( $post->ID ) );
+			if ( is_object( $object ) ) {
+				return $object;
 			}
 		}
 


### PR DESCRIPTION
But just an Object in general

This way you can use `wc_get_product` as `clarkson_core_create_object_callback` and therefore do things like `object.get_price()` in a template.

## Issue link
Fixes #236

## Description
Set return type to object.
Don't check of $object is instance of `Clarkson_Object`.

## How Has This Been Tested?
```
/**
  * Replace Clarkson_Object with one of the WC_Product
  */
add_filter('clarkson_core_create_object_callback', function ( $callback, $type, $post_id ){

	if( is_singular('product') ) {
		$GLOBALS['product'] = wc_get_product( $post_id );
		return 'wc_get_product';
	}

	if( is_post_type_archive('product') || is_tax('product_cat')) {
		return 'wc_get_product';
	}

	return $callback;
}, 10, 3);
```



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Please be aware that running `composer test` is broken, will open a different issue for that.

